### PR TITLE
fix(Login):  Allow periods, double-quotes and backticks in usernames.

### DIFF
--- a/ozpcenter/tests/test_utils.py
+++ b/ozpcenter/tests/test_utils.py
@@ -25,7 +25,22 @@ class UtilsTest(TestCase):
         """
         data_gen.run()
 
-    def test_make_keysafe(self):
+    def test_make_keysafe_unwanted(self):
         name = 'Test @string\'s !'
         key_name = utils.make_keysafe(name)
         self.assertEqual('teststrings', key_name)
+
+    def test_make_keysafe_period(self):
+        name = 'Test User Jr.'
+        key_name = utils.make_keysafe(name)
+        self.assertEqual('testuserjr.', key_name)
+
+    def test_make_keysafe_doublequote(self):
+        name = 'Robert "Bob" User'
+        key_name = utils.make_keysafe(name)
+        self.assertEqual('robert"bob"user', key_name)
+
+    def test_make_keysafe_backtick(self):
+        name = 'Unexpected`Name'
+        key_name = utils.make_keysafe(name)
+        self.assertEqual('unexpected`name', key_name)

--- a/ozpcenter/utils.py
+++ b/ozpcenter/utils.py
@@ -14,7 +14,7 @@ def make_keysafe(key):
 
     TODO: check for max length (250 chars by default for memcached)
     """
-    return re.sub(r'[^a-zA-Z0-9_-]+', '', key).lower()
+    return re.sub(r'[^a-zA-Z0-9_."`-]+', '', key).lower()
 
 
 def find_between(s, start, end):


### PR DESCRIPTION
#152