### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/db_migration/onetime_db_migration.py
+++ b/db_migration/onetime_db_migration.py
@@ -72,10 +72,10 @@ def get_columns(table):
 
     Columns will be in the same order as the values appear in the data
     """
-    with open('%s/%s.sql' % (SQL_FILE_PATH, table), 'r') as f:
+    with open('{0!s}/{1!s}.sql'.format(SQL_FILE_PATH, table), 'r') as f:
         data = f.read().replace('\n', '')
     # extract a string like (`id`, `version`, `created_by_id`)
-    columns = utils.find_between(data, "INSERT INTO `%s`" % table, " VALUES")
+    columns = utils.find_between(data, "INSERT INTO `{0!s}`".format(table), " VALUES")
     # remove parenthesis, backticks, and spaces
     columns = re.sub('[`() ]', '', columns)
     columns = columns.split(',')
@@ -90,7 +90,7 @@ def get_values(table, column_count):
         column_count: number of columns in this table
     """
     values = []
-    with open('%s/%s.sql' % (SQL_FILE_PATH, table), 'r') as f:
+    with open('{0!s}/{1!s}.sql'.format(SQL_FILE_PATH, table), 'r') as f:
         data = f.read().replace('\n', '')
     # extract the data we want
     values_str = utils.find_between(data, "VALUES ", ");") + ')'
@@ -146,7 +146,7 @@ def get_values(table, column_count):
                 # logging.debug('got string value: %s' % val)
                 # remove comma
                 if values_str[0] != ',' and columns_processed != column_count:
-                    logging.error('Error: comma not found after extracting string value. string[0]: %s' % values_str[0])
+                    logging.error('Error: comma not found after extracting string value. string[0]: {0!s}'.format(values_str[0]))
                     return None
                 if columns_processed < column_count:
                     values_str = values_str[1:]
@@ -179,7 +179,7 @@ def get_values(table, column_count):
                 if columns_processed < column_count:
                     values_str = values_str[1:]
             else:
-                logging.error('Error: found invalid character in data: %s' % values_str[0])
+                logging.error('Error: found invalid character in data: {0!s}'.format(values_str[0]))
                 return None
 
             if columns_processed == column_count:
@@ -264,7 +264,7 @@ def migrate_category():
     assert columns[7] == 'title'
     values = get_values('category', len(columns))
     # logging.debug('category columns: %s' % columns)
-    logging.info('Categories to migrate: %s' % len(values))
+    logging.info('Categories to migrate: {0!s}'.format(len(values)))
     # logging.debug('category values: %s' % values)
     # map old ids to new ones for future migrations: {'<old_id>': '<new_id>'}
     category_mapper = {}
@@ -273,7 +273,7 @@ def migrate_category():
         old_id = i[0]
         description = i[4]
         title = i[7]
-        logging.info('Adding category title: %s, description: %s' % (title, description))
+        logging.info('Adding category title: {0!s}, description: {1!s}'.format(title, description))
         cat = models.Category(description=description, title=title)
         cat.save()
         category_mapper[i[0]] = str(cat.id)
@@ -294,7 +294,7 @@ def migrate_agency():
     assert columns[8] == 'title'
     values = get_values('agency', len(columns))
     # logging.debug('category columns: %s' % columns)
-    logging.info('Agencies to migrate: %s' % len(values))
+    logging.info('Agencies to migrate: {0!s}'.format(len(values)))
     # logging.debug('agency values: %s' % values)
     # map old ids to new ones for future migrations: {'<old_id>': '<new_id>'}
     agency_mapper = {}
@@ -303,7 +303,7 @@ def migrate_agency():
         old_id = i[0]
         short_name = i[7]
         title = i[8]
-        logging.info('Adding agency title: %s, short_name: %s' % (title, short_name))
+        logging.info('Adding agency title: {0!s}, short_name: {1!s}'.format(title, short_name))
         a = models.Agency(short_name=short_name, title=title)
         a.save()
         agency_mapper[i[0]] = str(a.id)
@@ -323,7 +323,7 @@ def migrate_type():
     assert columns[7] == 'title'
     values = get_values('type', len(columns))
     # logging.debug('category columns: %s' % columns)
-    logging.info('Listing Types to migrate: %s' % len(values))
+    logging.info('Listing Types to migrate: {0!s}'.format(len(values)))
     # logging.debug('agency values: %s' % values)
     # map old ids to new ones for future migrations: {'<old_id>': '<new_id>'}
     type_mapper = {}
@@ -332,7 +332,7 @@ def migrate_type():
         old_id = i[0]
         description = i[4]
         title = i[7]
-        logging.info('Adding listing type title: %s, description: %s' % (title, description))
+        logging.info('Adding listing type title: {0!s}, description: {1!s}'.format(title, description))
         t = models.ListingType(title=title, description=description)
         t.save()
         type_mapper[i[0]] = str(t.id)
@@ -352,7 +352,7 @@ def migrate_contact_type():
     assert columns[7] == 'title'
     values = get_values('contact_type', len(columns))
     # logging.debug('category columns: %s' % columns)
-    logging.info('ContactTypes to migrate: %s' % len(values))
+    logging.info('ContactTypes to migrate: {0!s}'.format(len(values)))
     # logging.debug('agency values: %s' % values)
     # map old ids to new ones for future migrations: {'<old_id>': '<new_id>'}
     contact_type_mapper = {}
@@ -361,7 +361,7 @@ def migrate_contact_type():
         old_id = i[0]
         required = i[6]
         title = i[7]
-        logging.info('Adding contact_type title: %s, required: %s' % (title, required))
+        logging.info('Adding contact_type title: {0!s}, required: {1!s}'.format(title, required))
         ct = models.ContactType(name=title, required=required)
         ct.save()
         contact_type_mapper[i[0]] = str(ct.id)
@@ -386,7 +386,7 @@ def migrate_profile():
     assert columns[12] == 'launch_in_webtop'
     values = get_values('profile', len(columns))
     # logging.debug('category columns: %s' % columns)
-    logging.info('Profiles to migrate: %s' % len(values))
+    logging.info('Profiles to migrate: {0!s}'.format(len(values)))
     # logging.debug('agency values: %s' % values)
     # map old ids to new ones for future migrations: {'<old_id>': '<new_id>'}
     profile_mapper = {}
@@ -419,7 +419,7 @@ def migrate_profile():
         # be done automatically the first time authorization is checked
         p = models.Profile.create_user(username, **kwargs)
 
-        logging.info('Adding profile username: %s, display_name: %s, dn: %s' % (p.user.username, p.display_name, p.dn))
+        logging.info('Adding profile username: {0!s}, display_name: {1!s}, dn: {2!s}'.format(p.user.username, p.display_name, p.dn))
         profile_mapper[i[0]] = str(p.id)
     return profile_mapper
 
@@ -437,7 +437,7 @@ def migrate_notification(profile_mapper):
     assert columns[7] == 'expires_date'
     values = get_values('notification', len(columns))
     # logging.debug('category columns: %s' % columns)
-    logging.info('Notifications to migrate: %s' % len(values))
+    logging.info('Notifications to migrate: {0!s}'.format(len(values)))
     # logging.debug('agency values: %s' % values)
     # map old ids to new ones for future migrations: {'<old_id>': '<new_id>'}
     notification_mapper = {}
@@ -448,7 +448,7 @@ def migrate_notification(profile_mapper):
         expires_date = get_date_from_str(i[7])
         created_date = get_date_from_str(i[3])
         created_by_id = i[2]
-        logging.info('Adding notification message: %s, expires_date: %s' % (message, expires_date))
+        logging.info('Adding notification message: {0!s}, expires_date: {1!s}'.format(message, expires_date))
         p = models.Profile.objects.get(id=profile_mapper[created_by_id])
         n = models.Notification(message=message, expires_date=expires_date, created_date=created_date, author=p)
         n.save()
@@ -462,7 +462,7 @@ def migrate_profile_dismissed_notifications(profile_mapper, notification_mapper)
     assert columns[0] == 'notification_id'
     assert columns[1] == 'profile_id'
     values = get_values('profile_dismissed_notifications', len(columns))
-    logging.info('Dismissed notifications to migrate: %s' % len(values))
+    logging.info('Dismissed notifications to migrate: {0!s}'.format(len(values)))
     for i in values:
         notification_id = i[0]
         profile_id = i[1]
@@ -480,12 +480,12 @@ def migrate_image(image_uuid, image_type):
     VALID_IMAGE_TYPES = ['png', 'jpg', 'jpeg', 'gif']
     file_extension = None
     for i in VALID_IMAGE_TYPES:
-        filename = IMAGE_FILE_PATH + '/%s.%s' % (image_uuid, i)
+        filename = IMAGE_FILE_PATH + '/{0!s}.{1!s}'.format(image_uuid, i)
         if os.path.isfile(filename):
             file_extension = i
             break
     if not file_extension:
-        logging.error('Error: no file extension found for image %s' % image_uuid)
+        logging.error('Error: no file extension found for image {0!s}'.format(image_uuid))
         return
 
     # set default security marking
@@ -497,14 +497,14 @@ def migrate_image(image_uuid, image_type):
     src = filename
     dest = settings.MEDIA_ROOT + str(img.id) + '_' + img.image_type.name + '.' + file_extension
     shutil.copy(src, dest)
-    logging.info('Migrated image: %s, type: %s' % (image_uuid, image_type))
+    logging.info('Migrated image: {0!s}, type: {1!s}'.format(image_uuid, image_type))
     return img
 
 def migrate_listing(category_mapper, agency_mapper, type_mapper,
         contact_type_mapper, profile_mapper):
     logging.debug('migrating listings')
     columns = get_columns('listing')
-    logging.debug('listing columns: %s' % columns)
+    logging.debug('listing columns: {0!s}'.format(columns))
     # ['id', 'version', 'agency_id', 'approval_status', 'approved_date', 'avg_rate',
     #   'created_by_id', 'created_date', 'description', 'description_short',
     #   'edited_by_id', 'edited_date', 'small_icon_id', 'large_icon_id',
@@ -551,7 +551,7 @@ def migrate_listing(category_mapper, agency_mapper, type_mapper,
     assert columns[35] == 'height'
     values = get_values('listing', len(columns))
     # logging.debug('listing values: %s' % values)
-    logging.info('Listings to migrate: %s' % len(values))
+    logging.info('Listings to migrate: {0!s}'.format(len(values)))
 
     # map old ids to new ones for future migrations: {'<old_id>': '<new_id>'}
     listing_mapper = {}
@@ -597,7 +597,7 @@ def migrate_listing(category_mapper, agency_mapper, type_mapper,
             what_is_new = i[32]
             iframe_compatible = not i[34]
 
-            logging.info('Adding listing title: %s' % (title))
+            logging.info('Adding listing title: {0!s}'.format((title)))
             # TODO: unique_name?
             listing = models.Listing(title=title, agency=agency,
                 approval_status=approval_status, approved_date=approved_date,
@@ -616,7 +616,7 @@ def migrate_listing(category_mapper, agency_mapper, type_mapper,
             listing.save()
             listing_mapper[old_id] = str(listing.id)
         except Exception as e:
-            logging.error('Error processing listing %s: %s' % (title, str(e)))
+            logging.error('Error processing listing {0!s}: {1!s}'.format(title, str(e)))
 
     return listing_mapper
 
@@ -635,7 +635,7 @@ def migrate_application_library_entry(profile_mapper, listing_mapper):
     assert columns[8] == 'owner_id'
     values = get_values('application_library_entry', len(columns))
     # logging.debug('category columns: %s' % columns)
-    logging.info('Application Library Entries to migrate: %s' % len(values))
+    logging.info('Application Library Entries to migrate: {0!s}'.format(len(values)))
     logging.info('==========================')
     for i in values:
         try:
@@ -644,11 +644,11 @@ def migrate_application_library_entry(profile_mapper, listing_mapper):
             listing_id = i[7]
             listing = models.Listing.objects.get(id=listing_mapper[listing_id])
             owner = models.Profile.objects.get(id=profile_mapper[i[8]])
-            logging.info('Adding application_library_entry for listing %s, owner %s' % (listing.title, owner.user.username))
+            logging.info('Adding application_library_entry for listing {0!s}, owner {1!s}'.format(listing.title, owner.user.username))
             entry = models.ApplicationLibraryEntry(folder=folder, listing=listing, owner=owner)
             entry.save()
         except Exception as e:
-            logging.error('Error adding library entry: %s, values: %s' % (str(e), i))
+            logging.error('Error adding library entry: {0!s}, values: {1!s}'.format(str(e), i))
 
 def migrate_doc_url(listing_mapper):
     logging.debug('migrating doc_url...')
@@ -661,7 +661,7 @@ def migrate_doc_url(listing_mapper):
     assert columns[4] == 'url'
     values = get_values('doc_url', len(columns))
     # logging.debug('category columns: %s' % columns)
-    logging.info('Doc Urls to migrate: %s' % len(values))
+    logging.info('Doc Urls to migrate: {0!s}'.format(len(values)))
     logging.info('==========================')
     for i in values:
         try:
@@ -670,11 +670,11 @@ def migrate_doc_url(listing_mapper):
             name = i[3]
             url = i[4]
             listing = models.Listing.objects.get(id=listing_mapper[listing_id])
-            logging.info('Adding doc_url for listing %s, name %s' % (listing.title, name))
+            logging.info('Adding doc_url for listing {0!s}, name {1!s}'.format(listing.title, name))
             doc_url = models.DocUrl(name=name, url=url, listing=listing)
             doc_url.save()
         except Exception as e:
-            logging.error('Error adding doc_url entry: %s, values: %s' % (str(e), i))
+            logging.error('Error adding doc_url entry: {0!s}, values: {1!s}'.format(str(e), i))
 
 def migrate_item_comment(profile_mapper, listing_mapper):
     logging.debug('migrating item_comment...')
@@ -692,7 +692,7 @@ def migrate_item_comment(profile_mapper, listing_mapper):
     assert columns[9] == 'text'
     values = get_values('item_comment', len(columns))
     # logging.debug('category columns: %s' % columns)
-    logging.info('Reviews to migrate: %s' % len(values))
+    logging.info('Reviews to migrate: {0!s}'.format(len(values)))
     logging.info('==========================')
     for i in values:
         try:
@@ -704,10 +704,10 @@ def migrate_item_comment(profile_mapper, listing_mapper):
             text = i[9]
             review = models.Review(text=text, rate=rate,
                 edited_date=edited_date, author=author, listing=listing)
-            logging.info('Adding review for listing %s, rate: %s, text: %s' % (listing.title, rate, text))
+            logging.info('Adding review for listing {0!s}, rate: {1!s}, text: {2!s}'.format(listing.title, rate, text))
             review.save()
         except Exception as e:
-            logging.error('Error adding review entry: %s, values: %s' % (str(e), i))
+            logging.error('Error adding review entry: {0!s}, values: {1!s}'.format(str(e), i))
 
 def migrate_iwc_data_object(profile_mapper):
     logging.debug('migrating iwc_data_object...')
@@ -721,7 +721,7 @@ def migrate_iwc_data_object(profile_mapper):
     assert columns[5] == 'profile_id'
     values = get_values('iwc_data_object', len(columns))
     # logging.debug('category columns: %s' % columns)
-    logging.info('IWC data objects to migrate: %s' % len(values))
+    logging.info('IWC data objects to migrate: {0!s}'.format(len(values)))
     logging.info('==========================')
     for i in values:
         try:
@@ -733,11 +733,11 @@ def migrate_iwc_data_object(profile_mapper):
             # TODO: any modification here to match new api?
             data = iwc_models.DataResource(key=key, entity=entity,
                 content_type=content_type, username=profile.user.username)
-            logging.info('Adding iwc DataObject for user %s, key: %s, content_type: %s' % (
+            logging.info('Adding iwc DataObject for user {0!s}, key: {1!s}, content_type: {2!s}'.format(
                 profile.user.username, key, content_type))
             data.save()
         except Exception as e:
-            logging.error('Error adding iwc DataObject entry: %s, values: %s' % (str(e), i))
+            logging.error('Error adding iwc DataObject entry: {0!s}, values: {1!s}'.format(str(e), i))
 
 def migrate_listing_category(listing_mapper, category_mapper):
     logging.debug('migrating listing_category...')
@@ -747,7 +747,7 @@ def migrate_listing_category(listing_mapper, category_mapper):
     assert columns[1] == 'category_id'
     values = get_values('listing_category', len(columns))
     # logging.debug('category columns: %s' % columns)
-    logging.info('listing_category associations to migrate: %s' % len(values))
+    logging.info('listing_category associations to migrate: {0!s}'.format(len(values)))
     logging.info('==========================')
     for i in values:
         try:
@@ -755,10 +755,10 @@ def migrate_listing_category(listing_mapper, category_mapper):
             category_id = i[1]
             listing = models.Listing.objects.get(id=listing_mapper[listing_id])
             category = models.Category.objects.get(id=category_mapper[category_id])
-            logging.info('Adding category for listing %s, name %s' % (listing.title, category.title))
+            logging.info('Adding category for listing {0!s}, name {1!s}'.format(listing.title, category.title))
             listing.categories.add(category)
         except Exception as e:
-            logging.error('Error adding category %s to listing: %s, values: %s' % (category.title, listing.title, i))
+            logging.error('Error adding category {0!s} to listing: {1!s}, values: {2!s}'.format(category.title, listing.title, i))
 
 def migrate_listing_profile(profile_mapper, listing_mapper):
     # owners
@@ -769,7 +769,7 @@ def migrate_listing_profile(profile_mapper, listing_mapper):
     assert columns[1] == 'profile_id'
     values = get_values('listing_profile', len(columns))
     # logging.debug('category columns: %s' % columns)
-    logging.info('listing_profile associations to migrate: %s' % len(values))
+    logging.info('listing_profile associations to migrate: {0!s}'.format(len(values)))
     logging.info('==========================')
     for i in values:
         try:
@@ -777,10 +777,10 @@ def migrate_listing_profile(profile_mapper, listing_mapper):
             profile_id = i[1]
             listing = models.Listing.objects.get(id=listing_mapper[listing_id])
             profile = models.Profile.objects.get(id=profile_mapper[profile_id])
-            logging.info('Adding owner for listing %s, username %s' % (listing.title, profile.user.username))
+            logging.info('Adding owner for listing {0!s}, username {1!s}'.format(listing.title, profile.user.username))
             listing.owners.add(profile)
         except Exception as e:
-            logging.error('Error adding owner %s to listing: %s, values: %s' % (profile.user.username, listing.title, i))
+            logging.error('Error adding owner {0!s} to listing: {1!s}, values: {2!s}'.format(profile.user.username, listing.title, i))
 
 def migrate_listing_screenshot(listing_mapper):
     logging.debug('migrating screenshot...')
@@ -798,7 +798,7 @@ def migrate_listing_screenshot(listing_mapper):
     assert columns[9] == 'ordinal'
     values = get_values('screenshot', len(columns))
     # logging.debug('category columns: %s' % columns)
-    logging.info('Screenshots to migrate: %s' % len(values))
+    logging.info('Screenshots to migrate: {0!s}'.format(len(values)))
     logging.info('==========================')
     for i in values:
         try:
@@ -809,11 +809,11 @@ def migrate_listing_screenshot(listing_mapper):
             listing = models.Listing.objects.get(id=listing_mapper[listing_id])
             small_image = migrate_image(small_image_id, 'small_screenshot')
             large_image = migrate_image(large_image_id, 'large_screenshot')
-            logging.info('Adding screenshot for listing %s, large_image_id %s' % (listing.title, large_image_id))
+            logging.info('Adding screenshot for listing {0!s}, large_image_id {1!s}'.format(listing.title, large_image_id))
             screenshot = models.Screenshot(small_image=small_image, large_image=large_image, listing=listing)
             screenshot.save()
         except Exception as e:
-            logging.error('Error adding screenshot entry: %s, values: %s' % (str(e), i))
+            logging.error('Error adding screenshot entry: {0!s}, values: {1!s}'.format(str(e), i))
 
 def migrate_listing_tags(listing_mapper):
     logging.debug('migrating listing_tags...')
@@ -823,7 +823,7 @@ def migrate_listing_tags(listing_mapper):
     assert columns[1] == 'tags_string'
     values = get_values('listing_tags', len(columns))
     # logging.debug('category columns: %s' % columns)
-    logging.info('Tags to migrate: %s' % len(values))
+    logging.info('Tags to migrate: {0!s}'.format(len(values)))
     logging.info('==========================')
     for i in values:
         try:
@@ -835,11 +835,11 @@ def migrate_listing_tags(listing_mapper):
                 tag.save()
             except Exception:
                 tag = models.Tag.objects.get(name=name)
-            logging.info('Adding tag for listing %s, name %s' % (listing.title, tag))
+            logging.info('Adding tag for listing {0!s}, name {1!s}'.format(listing.title, tag))
             listing.tags.add(tag)
 
         except Exception as e:
-            logging.error('Error adding tag entry: %s, values: %s' % (str(e), i))
+            logging.error('Error adding tag entry: {0!s}, values: {1!s}'.format(str(e), i))
 
 def migrate_contact(listing_mapper, contact_type_mapper):
     logging.debug('migrating contact...')
@@ -862,7 +862,7 @@ def migrate_contact(listing_mapper, contact_type_mapper):
 
     values = get_values('contact', len(columns))
     # logging.debug('category columns: %s' % columns)
-    logging.info('Contacts to migrate: %s' % len(values))
+    logging.info('Contacts to migrate: {0!s}'.format(len(values)))
     logging.info('==========================')
     for i in values:
         try:
@@ -880,13 +880,13 @@ def migrate_contact(listing_mapper, contact_type_mapper):
                     unsecure_phone=unsecure_phone, contact_type=contact_type)
                 contact.save()
             except Exception:
-                logging.warning('Error: Found duplicate contact entry: %s' % name)
+                logging.warning('Error: Found duplicate contact entry: {0!s}'.format(name))
                 contact = models.Tag.objects.get(name=name)
-            logging.info('Adding contact %s for listing %s' % (name, listing.title))
+            logging.info('Adding contact {0!s} for listing {1!s}'.format(name, listing.title))
             listing.contacts.add(contact)
 
         except Exception as e:
-            logging.error('Error adding contact entry: %s, values: %s' % (str(e), i))
+            logging.error('Error adding contact entry: {0!s}, values: {1!s}'.format(str(e), i))
 
 def migrate_listing_activities(profile_mapper, listing_mapper):
     logging.debug('migrating listing_activity...')
@@ -906,7 +906,7 @@ def migrate_listing_activities(profile_mapper, listing_mapper):
     assert columns[10] == 'listing_activities_idx'
     values = get_values('listing_activity', len(columns))
     # logging.debug('category columns: %s' % columns)
-    logging.info('Listing Activities to migrate: %s' % len(values))
+    logging.info('Listing Activities to migrate: {0!s}'.format(len(values)))
     listing_activity_mapper = {}
     logging.info('==========================')
     for i in values:
@@ -918,13 +918,13 @@ def migrate_listing_activities(profile_mapper, listing_mapper):
             activity_date = get_date_from_str(i[8])
             author = models.Profile.objects.get(id=profile_mapper[author_id])
             listing = models.Listing.objects.get(id=listing_mapper[listing_id])
-            logging.info('Adding listing_activity %s for listing %s' % (action, listing.title))
+            logging.info('Adding listing_activity {0!s} for listing {1!s}'.format(action, listing.title))
             listing_activity = models.ListingActivity(action=action, activity_date=activity_date,
                 author=author, listing=listing)
             listing_activity.save()
             listing_activity_mapper[old_id] = str(listing_activity.id)
         except Exception as e:
-            logging.warning('Error adding listing_activity entry: %s, values: %s' % (str(e), i))
+            logging.warning('Error adding listing_activity entry: {0!s}, values: {1!s}'.format(str(e), i))
 
     return listing_activity_mapper
 
@@ -940,7 +940,7 @@ def migrate_change_detail(listing_activity_mapper):
     assert columns[5] == 'service_item_activity_id'
     values = get_values('change_detail', len(columns))
     # logging.debug('category columns: %s' % columns)
-    logging.info('Change details to migrate: %s' % len(values))
+    logging.info('Change details to migrate: {0!s}'.format(len(values)))
     logging.info('==========================')
     for i in values:
         try:
@@ -949,13 +949,13 @@ def migrate_change_detail(listing_activity_mapper):
             old_value = i[4]
             listing_activity_id = i[5]
             listing_activity = models.ListingActivity.objects.get(id=listing_activity_mapper[listing_activity_id])
-            logging.info('Adding change_detail for listing %s, field_name %s' % (listing_activity.listing.title, field_name))
+            logging.info('Adding change_detail for listing {0!s}, field_name {1!s}'.format(listing_activity.listing.title, field_name))
             change_detail = models.ChangeDetail(field_name=field_name,
                 old_value=old_value, new_value=new_value)
             change_detail.save()
             listing_activity.change_details.add(change_detail)
         except Exception as e:
-            logging.warning('Error adding change_detail %s, values: %s' % (field_name, i))
+            logging.warning('Error adding change_detail {0!s}, values: {1!s}'.format(field_name, i))
 
 def migrate_rejection_data(listing_mapper, listing_activity_mapper):
     """
@@ -968,7 +968,7 @@ def migrate_rejection_data(listing_mapper, listing_activity_mapper):
     assert columns[1] == 'rejection_listing_id'
     rejection_activity_values = get_values('rejection_activity', len(columns))
     # logging.debug('category columns: %s' % columns)
-    logging.info('Rejection activities to migrate: %s' % len(rejection_activity_values))
+    logging.info('Rejection activities to migrate: {0!s}'.format(len(rejection_activity_values)))
 
     logging.debug('getting data from rejection_listing...')
     columns = get_columns('rejection_listing')
@@ -985,7 +985,7 @@ def migrate_rejection_data(listing_mapper, listing_activity_mapper):
     assert columns[8] == 'service_item_id'
     rejection_listing_values = get_values('rejection_listing', len(columns))
     # logging.debug('category columns: %s' % columns)
-    logging.info('Rejection listings to migrate: %s' % len(rejection_listing_values))
+    logging.info('Rejection listings to migrate: {0!s}'.format(len(rejection_listing_values)))
 
     inverse_listing_activity_mapper = {v: k for k, v in listing_activity_mapper.items()}
 
@@ -995,7 +995,7 @@ def migrate_rejection_data(listing_mapper, listing_activity_mapper):
         if activity.action == 'REJECTED':
             found_description = False
             try:
-                logging.info('Found REJECTED action for listing %s' % activity.listing.title)
+                logging.info('Found REJECTED action for listing {0!s}'.format(activity.listing.title))
             except Exception:
                 logging.warning('Error: Found REJECTED action for non-existent listing')
                 continue
@@ -1006,7 +1006,7 @@ def migrate_rejection_data(listing_mapper, listing_activity_mapper):
                     for rejection_listing in rejection_listing_values:
                         if rejection_listing[0] == rejection_activity[1]:
                             description = rejection_listing[5]
-                            logging.info('Adding reason for rejection: %s' % description)
+                            logging.info('Adding reason for rejection: {0!s}'.format(description))
                             activity.description = description
                             activity.save()
                             found_description = True

--- a/ozp/tests/helper.py
+++ b/ozp/tests/helper.py
@@ -25,7 +25,7 @@ class MockResponse:
     def __init__(self, json_data, status_code):
         self.json_data = json_data
         self.status_code = status_code
-        self.text = 'Message: %s - Status: %s' % (self.json_data.get('message', 'N/A'), status_code)
+        self.text = 'Message: {0!s} - Status: {1!s}'.format(self.json_data.get('message', 'N/A'), status_code)
 
     def json(self):
         return self.json_data
@@ -59,7 +59,7 @@ class Router(object):
                     if hasattr(current_view, route.method):
                         current_method = getattr(current_view, route.method)
                     else:
-                        raise RuntimeError('Method [%s] does not exist on the view [%s]' % (route.method, current_view.__class__.__name__))
+                        raise RuntimeError('Method [{0!s}] does not exist on the view [{1!s}]'.format(route.method, current_view.__class__.__name__))
 
                     params = inspect.getargspec(current_method)
 
@@ -75,7 +75,7 @@ class Router(object):
 
             return MockResponse({'message': 'Mock Service - URL Not found', "URL": url}, 404)
         except RuntimeError as e:
-            return MockResponse({'message': 'Mock Service - %s' % str(e), "URL": url}, 404)
+            return MockResponse({'message': 'Mock Service - {0!s}'.format(str(e)), "URL": url}, 404)
 
 router = Router()
 plugin_manager_instance.load_mock_services(router)

--- a/ozpcenter/api/image/model_access.py
+++ b/ozpcenter/api/image/model_access.py
@@ -30,7 +30,7 @@ def get_image_path(pk):
     if os.path.isfile(image_path):
         return image_path
     else:
-        logger.error('image for pk %d does not exist' % pk)
+        logger.error('image for pk {0:d} does not exist'.format(pk))
         # TODO: raise exception
         return '/does/not/exist'
 

--- a/ozpcenter/api/image/views.py
+++ b/ozpcenter/api/image/views.py
@@ -124,7 +124,7 @@ class ImageViewSet(viewsets.ModelViewSet):
             serializer = serializers.ImageCreateSerializer(data=request.data,
                 context={'request': request})
             if not serializer.is_valid():
-                logger.error('%s' % serializer.errors)
+                logger.error('{0!s}'.format(serializer.errors))
                 return Response(serializer.errors,
                     status=status.HTTP_400_BAD_REQUEST)
             serializer.save()
@@ -160,7 +160,7 @@ class ImageViewSet(viewsets.ModelViewSet):
             with open(image_path, 'rb') as f:
                 return HttpResponse(f.read(), content_type=content_type)
         except IOError:
-            logger.error('No image found for pk %d' % pk)
+            logger.error('No image found for pk {0:d}'.format(pk))
             return Response(status=status.HTTP_404_NOT_FOUND)
 
     def destroy(self, request, pk=None):

--- a/ozpcenter/api/library/model_access.py
+++ b/ozpcenter/api/library/model_access.py
@@ -38,7 +38,7 @@ def get_library_entry_by_id(id):
 
     Key: library:<id>
     """
-    key = 'library:%s' % id
+    key = 'library:{0!s}'.format(id)
     data = cache.get(key)
     if data is None:
         try:
@@ -58,7 +58,7 @@ def get_self_application_library(username):
     Key: app_library:<username>
     """
     username = utils.make_keysafe(username)
-    key = 'app_library:%s' % username
+    key = 'app_library:{0!s}'.format(username)
     data = cache.get(key)
     if data is None:
         try:
@@ -82,7 +82,7 @@ def get_self_application_library_by_listing_type(username, listing_type):
     """
     username = utils.make_keysafe(username)
     listing_type_key = utils.make_keysafe(listing_type)
-    key = 'app_library_type(%s):%s' % (username, listing_type_key)
+    key = 'app_library_type({0!s}):{1!s}'.format(username, listing_type_key)
     data = cache.get(key)
     if data is None:
         try:

--- a/ozpcenter/api/library/serializers.py
+++ b/ozpcenter/api/library/serializers.py
@@ -85,7 +85,7 @@ class UserLibrarySerializer(serializers.ModelSerializer):
         folder = validated_data.get('folder', None)
         listing = listing_model_access.get_listing_by_id(username,
             validated_data['listing']['id'])
-        logger.debug('adding bookmark for %s' % listing.title, extra={'request': self.context.get('request')})
+        logger.debug('adding bookmark for {0!s}'.format(listing.title), extra={'request': self.context.get('request')})
         owner = generic_model_access.get_profile(username)
         entry = models.ApplicationLibraryEntry(listing=listing, owner=owner,
             folder=folder)

--- a/ozpcenter/api/library/tests/test_api_library.py
+++ b/ozpcenter/api/library/tests/test_api_library.py
@@ -91,7 +91,7 @@ class LibraryApiTest(APITestCase):
         """
         user = generic_model_access.get_profile(default_user).user
         self.client.force_authenticate(user=user)
-        url = '/api/listing/%s/' % id
+        url = '/api/listing/{0!s}/'.format(id)
         # GET Listing
         data = self.client.get(url, format='json').data
 

--- a/ozpcenter/api/library/views.py
+++ b/ozpcenter/api/library/views.py
@@ -114,7 +114,7 @@ class UserLibraryViewSet(viewsets.ViewSet):
         serializer = serializers.UserLibrarySerializer(data=request.data,
             context={'request': request})
         if not serializer.is_valid():
-            logger.error('%s' % serializer.errors)
+            logger.error('{0!s}'.format(serializer.errors))
             return Response(serializer.errors,
                 status=status.HTTP_400_BAD_REQUEST)
 

--- a/ozpcenter/api/listing/model_access.py
+++ b/ozpcenter/api/listing/model_access.py
@@ -85,7 +85,7 @@ def get_self_listings(username):
     Key: self_listings:<username>
     """
     username = utils.make_keysafe(username)
-    key = 'self_listings:%s' % username
+    key = 'self_listings:{0!s}'.format(username)
     data = cache.get(key)
     if data is None:
         try:
@@ -107,7 +107,7 @@ def get_listings(username):
     Key: listings:<username>
     """
     username = utils.make_keysafe(username)
-    key = 'listings:%s' % username
+    key = 'listings:{0!s}'.format(username)
     data = cache.get(key)
     if data is None:
         try:
@@ -127,7 +127,7 @@ def get_reviews(username):
     Key: reviews:<username>
     """
     username = utils.make_keysafe(username)
-    key = 'reviews:%s' % username
+    key = 'reviews:{0!s}'.format(username)
     data = cache.get(key)
     if data is None:
         try:
@@ -607,9 +607,9 @@ def image_to_string(image, queryset=False, extra_str=None):
         return None
 
     if queryset:
-        image_str = '%s.%s' % (image.id, image.security_marking)
+        image_str = '{0!s}.{1!s}'.format(image.id, image.security_marking)
     else:
-        image_str = '%s.%s' % (image.get('id'), image.get('security_marking', constants.DEFAULT_SECURITY_MARKING))
+        image_str = '{0!s}.{1!s}'.format(image.get('id'), image.get('security_marking', constants.DEFAULT_SECURITY_MARKING))
     return image_str
 
 

--- a/ozpcenter/api/listing/serializers.py
+++ b/ozpcenter/api/listing/serializers.py
@@ -297,7 +297,7 @@ class ListingSerializer(serializers.ModelSerializer):
         small_icon = data.get('small_icon', None)
         if small_icon:
             if 'id' not in small_icon:
-                raise serializers.ValidationError('Image(small_icon) requires a %s' % 'id')
+                raise serializers.ValidationError('Image(small_icon) requires a {0!s}'.format('id'))
             if small_icon.get('security_marking') is None:
                 small_icon['security_marking'] = constants.DEFAULT_SECURITY_MARKING
             if not access_control_instance.validate_marking(small_icon['security_marking']):
@@ -309,7 +309,7 @@ class ListingSerializer(serializers.ModelSerializer):
         large_icon = data.get('large_icon', None)
         if large_icon:
             if 'id' not in large_icon:
-                raise serializers.ValidationError('Image(large_icon) requires a %s' % 'id')
+                raise serializers.ValidationError('Image(large_icon) requires a {0!s}'.format('id'))
             if large_icon.get('security_marking') is None:
                 large_icon['security_marking'] = constants.DEFAULT_SECURITY_MARKING
             if not access_control_instance.validate_marking(large_icon['security_marking']):
@@ -321,7 +321,7 @@ class ListingSerializer(serializers.ModelSerializer):
         banner_icon = data.get('banner_icon', None)
         if banner_icon:
             if 'id' not in banner_icon:
-                raise serializers.ValidationError('Image(banner_icon) requires a %s' % 'id')
+                raise serializers.ValidationError('Image(banner_icon) requires a {0!s}'.format('id'))
             if banner_icon.get('security_marking') is None:
                 banner_icon['security_marking'] = constants.DEFAULT_SECURITY_MARKING
             if not access_control_instance.validate_marking(banner_icon['security_marking']):
@@ -333,7 +333,7 @@ class ListingSerializer(serializers.ModelSerializer):
         large_banner_icon = data.get('large_banner_icon', None)
         if large_banner_icon:
             if 'id' not in large_banner_icon:
-                raise serializers.ValidationError('Image(large_banner_icon) requires a %s' % 'id')
+                raise serializers.ValidationError('Image(large_banner_icon) requires a {0!s}'.format('id'))
             if large_banner_icon.get('security_marking') is None:
                 large_banner_icon['security_marking'] = constants.DEFAULT_SECURITY_MARKING
             if not access_control_instance.validate_marking(large_banner_icon['security_marking']):
@@ -350,17 +350,17 @@ class ListingSerializer(serializers.ModelSerializer):
                 if ('small_image' not in screenshot_set or
                         'large_image' not in screenshot_set):
                     raise serializers.ValidationError(
-                        'Screenshot Set requires %s fields' % 'small_image, large_icon')
+                        'Screenshot Set requires {0!s} fields'.format('small_image, large_icon'))
                 screenshot_small_image = screenshot_set.get('small_image')
                 screenshot_large_image = screenshot_set.get('large_image')
 
                 for field in image_require_fields:
                     if field not in screenshot_small_image:
-                        raise serializers.ValidationError('Screenshot Small Image requires a %s' % field)
+                        raise serializers.ValidationError('Screenshot Small Image requires a {0!s}'.format(field))
 
                 for field in image_require_fields:
                     if field not in screenshot_large_image:
-                        raise serializers.ValidationError('Screenshot Large Image requires a %s' % field)
+                        raise serializers.ValidationError('Screenshot Large Image requires a {0!s}'.format(field))
 
                 if not screenshot_small_image.get('security_marking'):
                     screenshot_small_image['security_marking'] = constants.DEFAULT_SECURITY_MARKING
@@ -387,7 +387,7 @@ class ListingSerializer(serializers.ModelSerializer):
                 for field in required_fields:
                     if field not in contact:
                         raise serializers.ValidationError(
-                            'Contact requires a %s' % field)
+                            'Contact requires a {0!s}'.format(field))
 
         owners = []
         if 'owners' in data:
@@ -439,7 +439,7 @@ class ListingSerializer(serializers.ModelSerializer):
         title = validated_data['title']
         user = generic_model_access.get_profile(
             self.context['request'].user.username)
-        logger.info('creating listing %s for user %s' % (title,
+        logger.info('creating listing {0!s} for user {1!s}'.format(title,
             user.user.username), extra={'request': self.context.get('request')})
 
         # assign a default security_marking level if none is provided
@@ -542,7 +542,7 @@ class ListingSerializer(serializers.ModelSerializer):
         if user.highest_role() not in ['APPS_MALL_STEWARD', 'ORG_STEWARD']:
             if user not in instance.owners.all():
                 raise errors.PermissionDenied(
-                    'User (%s) is not an owner of this listing' % user.username)
+                    'User ({0!s}) is not an owner of this listing'.format(user.username))
 
         if instance.is_deleted:
             raise errors.PermissionDenied(
@@ -613,8 +613,8 @@ class ListingSerializer(serializers.ModelSerializer):
         image_keys = ['small_icon', 'large_icon', 'banner_icon', 'large_banner_icon']
         for image_key in image_keys:
             if validated_data[image_key]:
-                old_value = model_access.image_to_string(getattr(instance, image_key), True, 'old_value(%s)' % image_key)
-                new_value = model_access.image_to_string(validated_data[image_key], False, 'new_value(%s)' % image_key)
+                old_value = model_access.image_to_string(getattr(instance, image_key), True, 'old_value({0!s})'.format(image_key))
+                new_value = model_access.image_to_string(validated_data[image_key], False, 'new_value({0!s})'.format(image_key))
 
                 if old_value != new_value:
                     new_value_image = None
@@ -748,7 +748,7 @@ class ListingSerializer(serializers.ModelSerializer):
                     new_doc_url_instances.append(obj)
                 for i in old_doc_url_instances:
                     if i not in new_doc_url_instances:
-                        logger.info('Deleting doc_url: %s' % i.id, extra={'request': self.context.get('request')})
+                        logger.info('Deleting doc_url: {0!s}'.format(i.id), extra={'request': self.context.get('request')})
                         i.delete()
 
         # screenshots will be automatically created
@@ -781,7 +781,7 @@ class ListingSerializer(serializers.ModelSerializer):
 
             for i in old_screenshot_instances:
                 if i not in new_screenshot_instances:
-                    logger.info('Deleting screenshot: %s' % i.id, extra={'request': self.context.get('request')})
+                    logger.info('Deleting screenshot: {0!s}'.format(i.id), extra={'request': self.context.get('request')})
                     i.delete()
 
         if 'agency' in validated_data:

--- a/ozpcenter/api/listing/tests/test_api_listing.py
+++ b/ozpcenter/api/listing/tests/test_api_listing.py
@@ -41,7 +41,7 @@ class ListingApiTest(APITestCase):
         Used to validate the keys of a listing
         """
         if not isinstance(listing_map, dict):
-            raise Exception('listing_map is not type dict, it is %s' % type(listing_map))
+            raise Exception('listing_map is not type dict, it is {0!s}'.format(type(listing_map)))
 
         listing_map_default_keys = ['id', 'is_bookmarked', 'screenshots',
                                     'doc_urls', 'owners', 'categories', 'tags', 'contacts', 'intents',
@@ -294,7 +294,7 @@ class ListingApiTest(APITestCase):
         user = generic_model_access.get_profile('wsmith').user
         self.client.force_authenticate(user=user)
         air_mail_id = models.Listing.objects.get(title='Air Mail').id
-        url = '/api/listing/%s/review/' % air_mail_id
+        url = '/api/listing/{0!s}/review/'.format(air_mail_id)
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -302,7 +302,7 @@ class ListingApiTest(APITestCase):
         user = generic_model_access.get_profile('wsmith').user
         self.client.force_authenticate(user=user)
         air_mail_id = models.Listing.objects.get(title='Air Mail').id
-        url = '/api/listing/%s/review/1/' % air_mail_id
+        url = '/api/listing/{0!s}/review/1/'.format(air_mail_id)
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue('rate' in response.data)
@@ -315,7 +315,7 @@ class ListingApiTest(APITestCase):
         user = generic_model_access.get_profile('wsmith').user
         self.client.force_authenticate(user=user)
         air_mail_id = models.Listing.objects.get(title='Air Mail').id
-        url = '/api/listing/%s/review/' % air_mail_id
+        url = '/api/listing/{0!s}/review/'.format(air_mail_id)
         data = {'rate': 4, 'text': 'winston test review'}
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -337,7 +337,7 @@ class ListingApiTest(APITestCase):
         bread_basket_id = models.Listing.objects.get(title='Bread Basket').id
         user = generic_model_access.get_profile('rutherford').user
         self.client.force_authenticate(user=user)
-        url = '/api/listing/%s/review/' % bread_basket_id
+        url = '/api/listing/{0!s}/review/'.format(bread_basket_id)
         data = {'rate': 4, 'text': 'rutherford test review'}
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -347,7 +347,7 @@ class ListingApiTest(APITestCase):
         user = generic_model_access.get_profile('julia').user
         self.client.force_authenticate(user=user)
         air_mail_id = models.Listing.objects.get(title='Air Mail').id
-        url = '/api/listing/%s/review/' % air_mail_id
+        url = '/api/listing/{0!s}/review/'.format(air_mail_id)
         data = {'rate': 3}
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -363,21 +363,21 @@ class ListingApiTest(APITestCase):
         user = generic_model_access.get_profile('wsmith').user
         self.client.force_authenticate(user=user)
         air_mail_id = models.Listing.objects.get(title='Air Mail').id
-        url = '/api/listing/%s/review/' % air_mail_id
+        url = '/api/listing/{0!s}/review/'.format(air_mail_id)
         data = {'rate': 4, 'text': 'winston test review'}
         response = self.client.post(url, data, format='json')
         review_id = response.data['id']
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         # now update it
-        url = '/api/listing/%s/review/%s/' % (air_mail_id, review_id)
+        url = '/api/listing/{0!s}/review/{1!s}/'.format(air_mail_id, review_id)
         data = {'rate': 4, 'text': 'winston test review'}
         response = self.client.put(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(4, response.data['rate'])
 
         # test the listing/<id>/activity endpoint
-        url = '/api/listing/%s/activity/' % air_mail_id
+        url = '/api/listing/{0!s}/activity/'.format(air_mail_id)
         response = self.client.get(url, format='json')
         activiy_actions = [i['action'] for i in response.data]
 
@@ -385,7 +385,7 @@ class ListingApiTest(APITestCase):
         self.assertTrue(models.ListingActivity.REVIEW_EDITED in activiy_actions)
 
         # try to edit a review from another user - should fail
-        url = '/api/listing/%s/review/1/' % air_mail_id
+        url = '/api/listing/{0!s}/review/1/'.format(air_mail_id)
         data = {'rate': 4, 'text': 'winston test review'}
         response = self.client.put(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -395,19 +395,19 @@ class ListingApiTest(APITestCase):
         user = generic_model_access.get_profile('rutherford').user
         self.client.force_authenticate(user=user)
         air_mail_id = models.Listing.objects.get(title='Air Mail').id
-        url = '/api/listing/%s/review/' % air_mail_id
+        url = '/api/listing/{0!s}/review/'.format(air_mail_id)
         data = {'rate': 4, 'text': 'rutherford test review'}
         response = self.client.post(url, data, format='json')
         review_id = response.data['id']
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         # now delete it
-        url = '/api/listing/%s/review/%s/' % (air_mail_id, review_id)
+        url = '/api/listing/{0!s}/review/{1!s}/'.format(air_mail_id, review_id)
         response = self.client.delete(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
         # test the listing/<id>/activity endpoint
-        url = '/api/listing/%s/activity/' % air_mail_id
+        url = '/api/listing/{0!s}/activity/'.format(air_mail_id)
         response = self.client.get(url, format='json')
         activiy_actions = [i['action'] for i in response.data]
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -418,14 +418,14 @@ class ListingApiTest(APITestCase):
         user = generic_model_access.get_profile('wsmith').user
         self.client.force_authenticate(user=user)
         air_mail_id = models.Listing.objects.get(title='Air Mail').id
-        url = '/api/listing/%s/review/' % air_mail_id
+        url = '/api/listing/{0!s}/review/'.format(air_mail_id)
         data = {'rate': 4, 'text': 'winston test review'}
         response = self.client.post(url, data, format='json')
         review_id = response.data['id']
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         # trying to delete it as a different user should fail...
-        url = '/api/listing/%s/review/%s/' % (air_mail_id, review_id)
+        url = '/api/listing/{0!s}/review/{1!s}/'.format(air_mail_id, review_id)
         user = generic_model_access.get_profile('jones').user
         self.client.force_authenticate(user=user)
         response = self.client.delete(url, format='json')
@@ -456,7 +456,7 @@ class ListingApiTest(APITestCase):
         self.assertEqual(listing.total_rate5, 0)
 
         # add one review
-        url = '/api/listing/%s/review/' % listing.id
+        url = '/api/listing/{0!s}/review/'.format(listing.id)
         data = {'rate': 1, 'text': 'winston test review'}
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -475,35 +475,35 @@ class ListingApiTest(APITestCase):
         # add a few more reviews
         user = generic_model_access.get_profile('julia').user
         self.client.force_authenticate(user=user)
-        url = '/api/listing/%s/review/' % listing.id
+        url = '/api/listing/{0!s}/review/'.format(listing.id)
         data = {'rate': 2, 'text': 'julia test review'}
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         user = generic_model_access.get_profile('charrington').user
         self.client.force_authenticate(user=user)
-        url = '/api/listing/%s/review/' % listing.id
+        url = '/api/listing/{0!s}/review/'.format(listing.id)
         data = {'rate': 3, 'text': 'charrington test review'}
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         user = generic_model_access.get_profile('jones').user
         self.client.force_authenticate(user=user)
-        url = '/api/listing/%s/review/' % listing.id
+        url = '/api/listing/{0!s}/review/'.format(listing.id)
         data = {'rate': 4, 'text': 'jones test review'}
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         user = generic_model_access.get_profile('rutherford').user
         self.client.force_authenticate(user=user)
-        url = '/api/listing/%s/review/' % listing.id
+        url = '/api/listing/{0!s}/review/'.format(listing.id)
         data = {'rate': 5, 'text': 'rutherford test review'}
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         user = generic_model_access.get_profile('syme').user
         self.client.force_authenticate(user=user)
-        url = '/api/listing/%s/review/' % listing.id
+        url = '/api/listing/{0!s}/review/'.format(listing.id)
         data = {'rate': 5, 'text': 'syme test review'}
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -512,7 +512,7 @@ class ListingApiTest(APITestCase):
         # and one without a review
         user = generic_model_access.get_profile('tparsons').user
         self.client.force_authenticate(user=user)
-        url = '/api/listing/%s/review/' % listing.id
+        url = '/api/listing/{0!s}/review/'.format(listing.id)
         data = {'rate': 4}
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -533,7 +533,7 @@ class ListingApiTest(APITestCase):
         # update an existing review
         user = generic_model_access.get_profile('tparsons').user
         self.client.force_authenticate(user=user)
-        url = '/api/listing/%s/review/%s/' % (listing.id,
+        url = '/api/listing/{0!s}/review/{1!s}/'.format(listing.id,
             tparsons_review_id)
         data = {'rate': 2}
         response = self.client.put(url, data, format='json')
@@ -554,7 +554,7 @@ class ListingApiTest(APITestCase):
         # delete an existing review
         user = generic_model_access.get_profile('syme').user
         self.client.force_authenticate(user=user)
-        url = '/api/listing/%s/review/%s/' % (listing.id, syme_review_id)
+        url = '/api/listing/{0!s}/review/{1!s}/'.format(listing.id, syme_review_id)
         response = self.client.delete(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
@@ -1257,7 +1257,7 @@ class ListingApiTest(APITestCase):
           "required_listings": None
         }
 
-        url = '/api/listing/%s/' % listing_id
+        url = '/api/listing/{0!s}/'.format(listing_id)
         response = self.client.put(url, data, format='json')
 
         contacts = response.data['contacts']
@@ -1285,7 +1285,7 @@ class ListingApiTest(APITestCase):
         data['approval_status'] = models.Listing.APPROVED
         listing_id = data['id']
 
-        url = '/api/listing/%s/' % listing_id
+        url = '/api/listing/{0!s}/'.format(listing_id)
         response = self.client.put(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
@@ -1310,7 +1310,7 @@ class ListingApiTest(APITestCase):
         data = response.data
 
         # VERIFY that is was created
-        url = '/api/listing/%s/activity/' % app_id
+        url = '/api/listing/{0!s}/activity/'.format(app_id)
         response = self._request_helper(url, 'GET', username='jones', status_code=200)
 
         activity_actions = [i['action'] for i in response.data]
@@ -1322,12 +1322,12 @@ class ListingApiTest(APITestCase):
 
         # MODIFIED
         data['title'] = "mr jones mod app"
-        url = '/api/listing/%s/' % app_id
+        url = '/api/listing/{0!s}/'.format(app_id)
         response = self._request_helper(url, 'PUT', data=data, username='jones', status_code=200)
         data = response.data
 
         # VERIFY that is was modified
-        url = '/api/listing/%s/activity/' % app_id
+        url = '/api/listing/{0!s}/activity/'.format(app_id)
         response = self._request_helper(url, 'GET', username='jones', status_code=200)
 
         activity_actions = [i['action'] for i in response.data]
@@ -1339,11 +1339,11 @@ class ListingApiTest(APITestCase):
 
         # SUBMITTED
         data['approval_status'] = models.Listing.PENDING
-        url = '/api/listing/%s/' % app_id
+        url = '/api/listing/{0!s}/'.format(app_id)
         response = self._request_helper(url, 'PUT', data=data, username='jones', status_code=200)
 
         # Verify that is was submitted
-        url = '/api/listing/%s/activity/' % app_id
+        url = '/api/listing/{0!s}/activity/'.format(app_id)
         response = self._request_helper(url, 'GET', username='jones', status_code=200)
 
         activity_actions = [i['action'] for i in response.data]
@@ -1360,11 +1360,11 @@ class ListingApiTest(APITestCase):
 
         # DISABLE
         data['is_enabled'] = False
-        url = '/api/listing/%s/' % app_id
+        url = '/api/listing/{0!s}/'.format(app_id)
         response = self._request_helper(url, 'PUT', data=data, username='jones', status_code=200)
 
         # Verify that it was disabled
-        url = '/api/listing/%s/activity/' % app_id
+        url = '/api/listing/{0!s}/activity/'.format(app_id)
         response = self._request_helper(url, 'GET', username='jones', status_code=200)
         activity_actions = [i['action'] for i in response.data]
         self.assertEquals(len(activity_actions), 4)
@@ -1375,11 +1375,11 @@ class ListingApiTest(APITestCase):
 
         # ENABLED
         data['is_enabled'] = True
-        url = '/api/listing/%s/' % app_id
+        url = '/api/listing/{0!s}/'.format(app_id)
         response = self._request_helper(url, 'PUT', data=data, username='jones', status_code=200)
 
         # Verify that it was enabled
-        url = '/api/listing/%s/activity/' % app_id
+        url = '/api/listing/{0!s}/activity/'.format(app_id)
         response = self._request_helper(url, 'GET', username='jones', status_code=200)
         activity_actions = [i['action'] for i in response.data]
         self.assertEquals(len(activity_actions), 5)
@@ -1422,13 +1422,13 @@ class ListingApiTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         titles = [i['listing']['title'] for i in response.data]
         titles = list(set(titles))
-        print('for bigbrother, got titles: %s' % titles)
+        print('for bigbrother, got titles: {0!s}'.format(titles))
         counter = 0
         for i in expected_titles:
             # Bread Basket is a private app, and bigbrother is not in that
             # organization
             if i != 'Bread Basket':
-                print('checking for app %s' % i)
+                print('checking for app {0!s}'.format(i))
                 self.assertTrue(i in titles)
                 counter += 1
         self.assertEqual(counter, len(expected_titles) - 1)

--- a/ozpcenter/api/listing/views.py
+++ b/ozpcenter/api/listing/views.py
@@ -390,7 +390,7 @@ class ListingViewSet(viewsets.ModelViewSet):
             serializer = serializers.ListingSerializer(data=request.data,
                 context={'request': request}, partial=True)
             if not serializer.is_valid():
-                logger.error('%s' % serializer.errors, extra={'request': request})
+                logger.error('{0!s}'.format(serializer.errors), extra={'request': request})
                 return Response(serializer.errors,
                     status=status.HTTP_400_BAD_REQUEST)
             serializer.save()
@@ -518,7 +518,7 @@ class ListingViewSet(viewsets.ModelViewSet):
             # logger.debug('created ListingSerializer', extra={'request': request})
 
             if not serializer.is_valid():
-                logger.error('%s' % serializer.errors, extra={'request': request})
+                logger.error('{0!s}'.format(serializer.errors), extra={'request': request})
                 return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
             serializer.save()

--- a/ozpcenter/api/notification/views.py
+++ b/ozpcenter/api/notification/views.py
@@ -36,7 +36,7 @@ class NotificationViewSet(viewsets.ModelViewSet):
             serializer = serializers.NotificationSerializer(data=request.data,
                 context={'request': request}, partial=True)
             if not serializer.is_valid():
-                logger.error('%s' % serializer.errors)
+                logger.error('{0!s}'.format(serializer.errors))
                 return Response(serializer.errors,
                     status=status.HTTP_400_BAD_REQUEST)
 
@@ -57,7 +57,7 @@ class NotificationViewSet(viewsets.ModelViewSet):
                 data=request.data, context={'request': request}, partial=True)
 
             if not serializer.is_valid():
-                logger.error('%s' % serializer.errors)
+                logger.error('{0!s}'.format(serializer.errors))
                 return Response(serializer.errors,
                     status=status.HTTP_400_BAD_REQUEST)
 

--- a/ozpcenter/api/profile/model_access.py
+++ b/ozpcenter/api/profile/model_access.py
@@ -48,7 +48,7 @@ def get_all_listings_for_profile_by_id(current_request_username, profile_id, lis
         titles_to_exclude = []
         for i in listings:
             if not i.security_marking:
-                logger.debug('Listing %s has no security_marking' % i.title)
+                logger.debug('Listing {0!s} has no security_marking'.format(i.title))
             if not access_control_instance.has_access(current_profile_instance.access_control, i.security_marking):
                 titles_to_exclude.append(i.title)
         listings = listings.exclude(title__in=titles_to_exclude)  # TODO: Base it on ids

--- a/ozpcenter/api/profile/tests/test_api_profile.py
+++ b/ozpcenter/api/profile/tests/test_api_profile.py
@@ -248,12 +248,12 @@ class ProfileApiTest(APITestCase):
                 # Get all '{role}' profiles at '{current_username}' access control level
                 user = generic_model_access.get_profile(current_username).user
                 self.client.force_authenticate(user=user)
-                url = '/api/profile/?role=%s' % role
+                url = '/api/profile/?role={0!s}'.format(role)
                 response = self.client.get(url, format='json')
                 self.assertEqual(response.status_code, status.HTTP_200_OK)
                 usernames = [i['user']['username'] for i in response.data]
 
-                self.assertEquals('bigbrother' in usernames, bool(combo[0]), 'bigbrother role [%s] in %s' % (role, bool(combo[0])))
+                self.assertEquals('bigbrother' in usernames, bool(combo[0]), 'bigbrother role [{0!s}] in {1!s}'.format(role, bool(combo[0])))
                 self.assertEquals('julia' in usernames, bool(combo[1]))
                 self.assertEquals('jones' in usernames, bool(combo[2]))
                 displaynames = [i['display_name'] for i in response.data]

--- a/ozpcenter/api/profile/views.py
+++ b/ozpcenter/api/profile/views.py
@@ -59,7 +59,7 @@ class ProfileViewSet(viewsets.ModelViewSet):
             serializer = serializers.ProfileSerializer(profile_instance,
                 data=request.data, context={'request': request}, partial=True)
             if not serializer.is_valid():
-                logger.error('%s' % serializer.errors)
+                logger.error('{0!s}'.format(serializer.errors))
                 return Response(serializer.errors,
                     status=status.HTTP_400_BAD_REQUEST)
 
@@ -181,7 +181,7 @@ class CurrentUserViewSet(viewsets.ViewSet):
             serializer = serializers.ProfileSerializer(current_request_profile,
                 data=request.data, context={'request': request}, partial=True)
             if not serializer.is_valid():
-                logger.error('%s' % serializer.errors)
+                logger.error('{0!s}'.format(serializer.errors))
                 return Response(serializer.errors,
                     status=status.HTTP_400_BAD_REQUEST)
 

--- a/ozpcenter/api/storefront/model_access.py
+++ b/ozpcenter/api/storefront/model_access.py
@@ -59,7 +59,7 @@ def get_storefront(username):
             'most_popular': most_popular_listings
         }
     except Exception as e:
-        return {'error': True, 'msg': 'Error getting storefront: %s' % str(e)}
+        return {'error': True, 'msg': 'Error getting storefront: {0!s}'.format(str(e))}
     return data
 
 
@@ -104,5 +104,5 @@ def get_metadata(username):
 
             cache.set(key, data)
         except Exception as e:
-            return {'error': True, 'msg': 'Error getting metadata: %s' % str(e)}
+            return {'error': True, 'msg': 'Error getting metadata: {0!s}'.format(str(e))}
     return data

--- a/ozpcenter/model_access.py
+++ b/ozpcenter/model_access.py
@@ -20,7 +20,7 @@ def get_profile(username):
     Key: current_profile:<username>
     """
     username = utils.make_keysafe(username)
-    key = 'current_profile:%s' % username
+    key = 'current_profile:{0!s}'.format(username)
 
     data = cache.get(key)
     if data is None:

--- a/ozpcenter/models.py
+++ b/ozpcenter/models.py
@@ -138,7 +138,7 @@ class Image(models.Model):
         file_extension = kwargs.get('file_extension', 'png')
         valid_extensions = constants.VALID_IMAGE_TYPES
         if file_extension not in valid_extensions:
-            logger.error('Invalid image type: %s' % file_extension)
+            logger.error('Invalid image type: {0!s}'.format(file_extension))
             # TODO: raise exception?
             return
 
@@ -166,8 +166,8 @@ class Image(models.Model):
         # To avoid unexpected image save error, make the max_size_bytes
         # larger than we expect
         if size_bytes > (image_type.max_size_bytes * 2):
-            logger.error('Image size is %d bytes, which is larger than the max \
-                allowed %d bytes' % (size_bytes, 2 * image_type.max_size_bytes))
+            logger.error('Image size is {0:d} bytes, which is larger than the max \
+                allowed {1:d} bytes'.format(size_bytes, 2 * image_type.max_size_bytes))
             # TODO raise exception and remove file
             return
 
@@ -253,11 +253,11 @@ class ApplicationLibraryEntry(models.Model):
         'Listing', related_name='application_library_entries')
 
     def __str__(self):
-        return '%s:%s:%s' % (self.folder, self.owner.user.username,
+        return '{0!s}:{1!s}:{2!s}'.format(self.folder, self.owner.user.username,
                              self.listing.title)
 
     def __repr__(self):
-        return '%s:%s:%s' % (self.folder, self.owner.user.username,
+        return '{0!s}:{1!s}:{2!s}'.format(self.folder, self.owner.user.username,
                              self.listing.title)
 
     class Meta:
@@ -300,7 +300,7 @@ class ChangeDetail(models.Model):
                                  blank=True, null=True)
 
     def __repr__(self):
-        return "id:%d field %s was %s now is %s" % (
+        return "id:{0:d} field {1!s} was {2!s} now is {3!s}".format(
             self.id, self.field_name, self.old_value, self.new_value)
 
 
@@ -351,18 +351,18 @@ class Contact(models.Model):
                 be blank'})
 
     def __repr__(self):
-        val = '%s, %s' % (self.name, self.email)
-        val += 'organization %s' % (
-            self.organization if self.organization else '')
-        val += 'secure_phone %s' % (
-            self.secure_phone if self.secure_phone else '')
-        val += 'unsecure_phone %s' % (
-            self.unsecure_phone if self.unsecure_phone else '')
+        val = '{0!s}, {1!s}'.format(self.name, self.email)
+        val += 'organization {0!s}'.format((
+            self.organization if self.organization else ''))
+        val += 'secure_phone {0!s}'.format((
+            self.secure_phone if self.secure_phone else ''))
+        val += 'unsecure_phone {0!s}'.format((
+            self.unsecure_phone if self.unsecure_phone else ''))
 
         return val
 
     def __str__(self):
-        return '%s: %s' % (self.name, self.email)
+        return '{0!s}: {1!s}'.format(self.name, self.email)
 
 
 class ContactType(models.Model):
@@ -401,10 +401,10 @@ class DocUrl(models.Model):
     listing = models.ForeignKey('Listing', related_name='doc_urls')
 
     def __repr__(self):
-        return '%s:%s' % (self.name, self.url)
+        return '{0!s}:{1!s}'.format(self.name, self.url)
 
     def __str__(self):
-        return '%s: %s' % (self.name, self.url)
+        return '{0!s}: {1!s}'.format(self.name, self.url)
 
 
 class Intent(models.Model):
@@ -434,7 +434,7 @@ class Intent(models.Model):
     icon = models.ForeignKey(Image, related_name='intent')
 
     def __repr__(self):
-        return '%s/%s' % (self.type, self.action)
+        return '{0!s}/{1!s}'.format(self.type, self.action)
 
     def __str__(self):
         return self.action
@@ -482,11 +482,11 @@ class Review(models.Model):
     edited_date = models.DateTimeField(default=utils.get_now_utc)
 
     def __repr__(self):
-        return '%s: rate: %d text: %s' % (self.author.user.username,
+        return '{0!s}: rate: {1:d} text: {2!s}'.format(self.author.user.username,
                                           self.rate, self.text)
 
     def __str__(self):
-        return '%s: rate: %d text: %s' % (self.author.user.username,
+        return '{0!s}: rate: {1:d} text: {2!s}'.format(self.author.user.username,
                                           self.rate, self.text)
 
     class Meta:
@@ -557,7 +557,7 @@ class Profile(models.Model):
     # django_user
 
     def __repr__(self):
-        return 'Profile: %s' % self.user.username
+        return 'Profile: {0!s}'.format(self.user.username)
 
     def __str__(self):
         return self.user.username
@@ -592,7 +592,7 @@ class Profile(models.Model):
             return 'USER'
         else:
             # TODO: raise exception?
-            logger.error('User %s has invalid Group' % self.user.username)
+            logger.error('User {0!s} has invalid Group'.format(self.user.username))
             return ''
 
     @staticmethod
@@ -709,7 +709,7 @@ class AccessControlListingManager(models.Manager):
         titles_to_exclude = []
         for i in objects:
             if not i.security_marking:
-                logger.debug('Listing %s has no security_marking' % i.title)
+                logger.debug('Listing {0!s} has no security_marking'.format(i.title))
             if not access_control_instance.has_access(user.access_control, i.security_marking):
                 titles_to_exclude.append(i.title)
         objects = objects.exclude(title__in=titles_to_exclude)
@@ -843,10 +843,10 @@ class Listing(models.Model):
         return ApplicationLibraryEntry.objects.filter(listing=self).count() >= 1
 
     def __repr__(self):
-        return '(%s-%s)' % (self.unique_name, [owner.user.username for owner in self.owners.all()])
+        return '({0!s}-{1!s})'.format(self.unique_name, [owner.user.username for owner in self.owners.all()])
 
     def __str__(self):
-        return '(%s-%s)' % (self.unique_name, [owner.user.username for owner in self.owners.all()])
+        return '({0!s}-{1!s})'.format(self.unique_name, [owner.user.username for owner in self.owners.all()])
 
 
 class AccessControlListingActivityManager(models.Manager):
@@ -934,11 +934,11 @@ class ListingActivity(models.Model):
     objects = AccessControlListingActivityManager()
 
     def __repr__(self):
-        return '%s %s %s at %s' % (self.author.user.username, self.action,
+        return '{0!s} {1!s} {2!s} at {3!s}'.format(self.author.user.username, self.action,
                                    self.listing.title, self.activity_date)
 
     def __str__(self):
-        return '%s %s %s at %s' % (self.author.user.username, self.action,
+        return '{0!s} {1!s} {2!s} at {3!s}'.format(self.author.user.username, self.action,
                                    self.listing.title, self.activity_date)
 
     class Meta:
@@ -959,10 +959,10 @@ class Screenshot(models.Model):
     listing = models.ForeignKey('Listing', related_name='screenshots')
 
     def __repr__(self):
-        return '%s: %s, %s' % (self.listing.title, self.large_image.id, self.small_image.id)
+        return '{0!s}: {1!s}, {2!s}'.format(self.listing.title, self.large_image.id, self.small_image.id)
 
     def __str__(self):
-        return '%s: %s, %s' % (self.listing.title, self.large_image.id, self.small_image.id)
+        return '{0!s}: {1!s}, {2!s}'.format(self.listing.title, self.large_image.id, self.small_image.id)
 
 
 class ListingType(models.Model):
@@ -1005,7 +1005,7 @@ class Notification(models.Model):
                                 null=True, blank=True)
 
     def __repr__(self):
-        return '%s: %s' % (self.author.user.username, self.message)
+        return '{0!s}: {1!s}'.format(self.author.user.username, self.message)
 
     def __str__(self):
-        return '%s: %s' % (self.author.user.username, self.message)
+        return '{0!s}: {1!s}'.format(self.author.user.username, self.message)

--- a/ozpcenter/scripts/sample_data_generator.py
+++ b/ozpcenter/scripts/sample_data_generator.py
@@ -475,13 +475,13 @@ def run():
         #                           Listing
         # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
         listing = models.Listing(
-            title='Air Mail%s' % postfix_space,
+            title='Air Mail{0!s}'.format(postfix_space),
             agency=minitrue,
             listing_type=web_app,
             description='Sends mail via air',
-            launch_url='%s/demo_apps/centerSampleListings/airMail/index.html' % DEMO_APP_ROOT,
+            launch_url='{0!s}/demo_apps/centerSampleListings/airMail/index.html'.format(DEMO_APP_ROOT),
             version_name='1.0.0',
-            unique_name='ozp.test.air_mail%s' % postfix_dot,
+            unique_name='ozp.test.air_mail{0!s}'.format(postfix_dot),
             small_icon=small_icon,
             large_icon=large_icon,
             banner_icon=banner_icon,
@@ -588,13 +588,13 @@ def run():
         #                           Listing
         # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
         listing = models.Listing(
-            title='Bread Basket%s' % postfix_space,
+            title='Bread Basket{0!s}'.format(postfix_space),
             agency=minitrue,
             listing_type=web_app,
             description='Carries delicious bread',
-            launch_url='%s/demo_apps/centerSampleListings/breadBasket/index.html' % DEMO_APP_ROOT,
+            launch_url='{0!s}/demo_apps/centerSampleListings/breadBasket/index.html'.format(DEMO_APP_ROOT),
             version_name='1.0.0',
-            unique_name='ozp.test.bread_basket%s' % postfix_dot,
+            unique_name='ozp.test.bread_basket{0!s}'.format(postfix_dot),
             small_icon=small_icon,
             large_icon=large_icon,
             banner_icon=banner_icon,
@@ -655,13 +655,13 @@ def run():
         # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
         listing = models.Listing(
-            title='Chart Course%s' % postfix_space,
+            title='Chart Course{0!s}'.format(postfix_space),
             agency=minitrue,
             listing_type=web_app,
             description='Chart your course',
-            launch_url='%s/demo_apps/centerSampleListings/chartCourse/index.html' % DEMO_APP_ROOT,
+            launch_url='{0!s}/demo_apps/centerSampleListings/chartCourse/index.html'.format(DEMO_APP_ROOT),
             version_name='1.0.0',
-            unique_name='ozp.test.chartcourse%s' % postfix_dot,
+            unique_name='ozp.test.chartcourse{0!s}'.format(postfix_dot),
             small_icon=small_icon,
             large_icon=large_icon,
             banner_icon=banner_icon,
@@ -711,13 +711,13 @@ def run():
         # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
         listing = models.Listing(
-            title='Chatter Box%s' % postfix_space,
+            title='Chatter Box{0!s}'.format(postfix_space),
             agency=miniluv,
             listing_type=web_app,
             description='Chat with people',
-            launch_url='%s/demo_apps/centerSampleListings/chatterBox/index.html' % DEMO_APP_ROOT,
+            launch_url='{0!s}/demo_apps/centerSampleListings/chatterBox/index.html'.format(DEMO_APP_ROOT),
             version_name='1.0.0',
-            unique_name='ozp.test.chatterbox%s' % postfix_dot,
+            unique_name='ozp.test.chatterbox{0!s}'.format(postfix_dot),
             small_icon=small_icon,
             large_icon=large_icon,
             banner_icon=banner_icon,
@@ -766,13 +766,13 @@ def run():
         # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
         listing = models.Listing(
-            title='Clipboard%s' % postfix_space,
+            title='Clipboard{0!s}'.format(postfix_space),
             agency=minitrue,
             listing_type=web_app,
             description='Clip stuff on a board',
-            launch_url='%s/demo_apps/centerSampleListings/clipboard/index.html' % DEMO_APP_ROOT,
+            launch_url='{0!s}/demo_apps/centerSampleListings/clipboard/index.html'.format(DEMO_APP_ROOT),
             version_name='1.0.0',
-            unique_name='ozp.test.clipboard%s' % postfix_dot,
+            unique_name='ozp.test.clipboard{0!s}'.format(postfix_dot),
             small_icon=small_icon,
             large_icon=large_icon,
             banner_icon=banner_icon,
@@ -822,13 +822,13 @@ def run():
         # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
         listing = models.Listing(
-            title='FrameIt%s' % postfix_space,
+            title='FrameIt{0!s}'.format(postfix_space),
             agency=minitrue,
             listing_type=web_app,
             description='Show things in an iframe',
-            launch_url='%s/demo_apps/frameit/index.html' % DEMO_APP_ROOT,
+            launch_url='{0!s}/demo_apps/frameit/index.html'.format(DEMO_APP_ROOT),
             version_name='1.0.0',
-            unique_name='ozp.test.frameit%s' % postfix_dot,
+            unique_name='ozp.test.frameit{0!s}'.format(postfix_dot),
             small_icon=small_icon,
             large_icon=large_icon,
             banner_icon=banner_icon,
@@ -878,13 +878,13 @@ def run():
         # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
         listing = models.Listing(
-            title='Hatch Latch%s' % postfix_space,
+            title='Hatch Latch{0!s}'.format(postfix_space),
             agency=minitrue,
             listing_type=web_app,
             description='Hatch latches',
-            launch_url='%s/demo_apps/centerSampleListings/hatchLatch/index.html' % DEMO_APP_ROOT,
+            launch_url='{0!s}/demo_apps/centerSampleListings/hatchLatch/index.html'.format(DEMO_APP_ROOT),
             version_name='1.0.0',
-            unique_name='ozp.test.hatchlatch%s' % postfix_dot,
+            unique_name='ozp.test.hatchlatch{0!s}'.format(postfix_dot),
             small_icon=small_icon,
             large_icon=large_icon,
             banner_icon=banner_icon,
@@ -935,13 +935,13 @@ def run():
         # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
         listing = models.Listing(
-            title='JotSpot%s' % postfix_space,
+            title='JotSpot{0!s}'.format(postfix_space),
             agency=minitrue,
             listing_type=web_app,
             description='Jot things down',
-            launch_url='%s/demo_apps/centerSampleListings/jotSpot/index.html' % DEMO_APP_ROOT,
+            launch_url='{0!s}/demo_apps/centerSampleListings/jotSpot/index.html'.format(DEMO_APP_ROOT),
             version_name='1.0.0',
-            unique_name='ozp.test.jotspot%s' % postfix_dot,
+            unique_name='ozp.test.jotspot{0!s}'.format(postfix_dot),
             small_icon=small_icon,
             large_icon=large_icon,
             banner_icon=banner_icon,
@@ -995,13 +995,13 @@ def run():
         # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
         listing = models.Listing(
-            title='LocationLister%s' % postfix_space,
+            title='LocationLister{0!s}'.format(postfix_space),
             agency=minitrue,
             listing_type=web_app,
             description='List locations',
-            launch_url='%s/demo_apps/locationLister/index.html' % DEMO_APP_ROOT,
+            launch_url='{0!s}/demo_apps/locationLister/index.html'.format(DEMO_APP_ROOT),
             version_name='1.0.0',
-            unique_name='ozp.test.locationlister%s' % postfix_dot,
+            unique_name='ozp.test.locationlister{0!s}'.format(postfix_dot),
             small_icon=small_icon,
             large_icon=large_icon,
             banner_icon=banner_icon,
@@ -1051,13 +1051,13 @@ def run():
         # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
         listing = models.Listing(
-            title='LocationViewer%s' % postfix_space,
+            title='LocationViewer{0!s}'.format(postfix_space),
             agency=minitrue,
             listing_type=web_app,
             description='View locations',
-            launch_url='%s/demo_apps/locationViewer/index.html' % DEMO_APP_ROOT,
+            launch_url='{0!s}/demo_apps/locationViewer/index.html'.format(DEMO_APP_ROOT),
             version_name='1.0.0',
-            unique_name='ozp.test.locationviewer%s' % postfix_dot,
+            unique_name='ozp.test.locationviewer{0!s}'.format(postfix_dot),
             small_icon=small_icon,
             large_icon=large_icon,
             banner_icon=banner_icon,
@@ -1107,13 +1107,13 @@ def run():
         # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
         listing = models.Listing(
-            title='LocationAnalyzer%s' % postfix_space,
+            title='LocationAnalyzer{0!s}'.format(postfix_space),
             agency=minitrue,
             listing_type=web_app,
             description='Analyze locations',
-            launch_url='%s/demo_apps/locationAnalyzer/index.html' % DEMO_APP_ROOT,
+            launch_url='{0!s}/demo_apps/locationAnalyzer/index.html'.format(DEMO_APP_ROOT),
             version_name='1.0.0',
-            unique_name='ozp.test.locationanalyzer%s' % postfix_dot,
+            unique_name='ozp.test.locationanalyzer{0!s}'.format(postfix_dot),
             small_icon=small_icon,
             large_icon=large_icon,
             banner_icon=banner_icon,

--- a/ozpiwc/api/data/serializers.py
+++ b/ozpiwc/api/data/serializers.py
@@ -46,7 +46,7 @@ class DataResourceSerializer(serializers.Serializer):
             pattern=validated_data['pattern'],
             permissions=validated_data['permissions'])
         data_resource.save()
-        logger.debug('saved NEW resource with key: %s, entity: %s' % (self.context['key'], validated_data['entity']))
+        logger.debug('saved NEW resource with key: {0!s}, entity: {1!s}'.format(self.context['key'], validated_data['entity']))
         return data_resource
 
     def update(self, instance, validated_data):
@@ -55,5 +55,5 @@ class DataResourceSerializer(serializers.Serializer):
         instance.pattern = validated_data['pattern']
         instance.permissions = validated_data['permissions']
         instance.save()
-        logger.debug('saved EXISTING resource with key: %s, entity: %s' % (self.context['key'], validated_data['entity']))
+        logger.debug('saved EXISTING resource with key: {0!s}, entity: {1!s}'.format(self.context['key'], validated_data['entity']))
         return instance

--- a/ozpiwc/api/data/views.py
+++ b/ozpiwc/api/data/views.py
@@ -55,7 +55,7 @@ def ListDataApiView(request):
                 data=request.data, context={'request': request, 'key': key},
                 partial=True)
             if not serializer.is_valid():
-                logger.error('%s' % serializer.errors)
+                logger.error('{0!s}'.format(serializer.errors))
                 return Response(serializer.errors,
                     status=status.HTTP_400_BAD_REQUEST)
             item = hal.add_hal_structure(serializer.data, request,
@@ -88,7 +88,7 @@ def DataApiView(request, key=None):
     if key.endswith('/'):
         key = key[:-1]
 
-    logger.debug('Got IWC Data request for key %s' % key)
+    logger.debug('Got IWC Data request for key {0!s}'.format(key))
 
     if not hal.validate_version(request.META.get('HTTP_ACCEPT')):
         return Response('Invalid version requested',
@@ -101,7 +101,7 @@ def DataApiView(request, key=None):
 
     if request.method == 'PUT':
         try:
-            logger.debug('request.data: %s' % request.data)
+            logger.debug('request.data: {0!s}'.format(request.data))
             instance = model_access.get_data_resource(request.user.username,
                 key)
             if instance:
@@ -109,7 +109,7 @@ def DataApiView(request, key=None):
                     data=request.data, context={'request': request, 'key': key},
                     partial=True)
                 if not serializer.is_valid():
-                    logger.error('%s' % serializer.errors)
+                    logger.error('{0!s}'.format(serializer.errors))
                     return Response(serializer.errors,
                         status=status.HTTP_400_BAD_REQUEST)
                 serializer.save()
@@ -123,7 +123,7 @@ def DataApiView(request, key=None):
                     data=request.data, context={'request': request, 'key': key},
                     partial=True)
                 if not serializer.is_valid():
-                    logger.error('ERROR: %s' % serializer.errors)
+                    logger.error('ERROR: {0!s}'.format(serializer.errors))
                     return Response(serializer.errors,
                         status=status.HTTP_400_BAD_REQUEST)
                 serializer.save()
@@ -147,7 +147,7 @@ def DataApiView(request, key=None):
                 data=request.data, context={'request': request, 'key': key},
                 partial=True)
             if not serializer.is_valid():
-                logger.error('%s' % serializer.errors)
+                logger.error('{0!s}'.format(serializer.errors))
                 return Response(serializer.errors,
                     status=status.HTTP_400_BAD_REQUEST)
             resp = serializer.data

--- a/ozpiwc/api/intent/views.py
+++ b/ozpiwc/api/intent/views.py
@@ -38,7 +38,7 @@ def IntentListView(request):
     intents = intent_model_access.get_all_intents()
     items = []
     for i in intents:
-        item = {"href": '%sintent/%s/' % (root_url, i.id)}
+        item = {"href": '{0!s}intent/{1!s}/'.format(root_url, i.id)}
         items.append(item)
     data['_links']['item'] = items
 

--- a/ozpiwc/api/system/test_api_system.py
+++ b/ozpiwc/api/system/test_api_system.py
@@ -33,7 +33,7 @@ class SystemApiTest(APITestCase):
     def test_listings(self):
         user = generic_model_access.get_profile('wsmith').user
         self.client.force_authenticate(user=user)
-        url = '/iwc-api/profile/%s/application/' % user.id
+        url = '/iwc-api/profile/{0!s}/application/'.format(user.id)
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue('_links' in response.data)

--- a/ozpiwc/api/system/views.py
+++ b/ozpiwc/api/system/views.py
@@ -39,7 +39,7 @@ def ApplicationListView(request):
     items = []
     embedded_items = []
     for i in applications:
-        item = {"href": '%slisting/%s/' % (listing_root_url, i.id),
+        item = {"href": '{0!s}listing/{1!s}/'.format(listing_root_url, i.id),
             "type": hal.generate_content_type(renderers.ApplicationResourceRenderer.media_type)}
         items.append(item)
 

--- a/ozpiwc/hal.py
+++ b/ozpiwc/hal.py
@@ -29,7 +29,7 @@ def create_base_structure(request, type='application/json'):
                 "templated": True
             },
             "self": {
-                "href": '%s' % request.build_absolute_uri(request.path),
+                "href": '{0!s}'.format(request.build_absolute_uri(request.path)),
                 "type": type
             }
         },
@@ -51,7 +51,7 @@ def add_hal_structure(data, request, type='application/json'):
             "templated": True
         },
         "self": {
-            "href": '%s' % request.build_absolute_uri(request.path),
+            "href": '{0!s}'.format(request.build_absolute_uri(request.path)),
             "type": type
         }
     }
@@ -61,12 +61,12 @@ def add_hal_structure(data, request, type='application/json'):
 
 def get_abs_url_for_profile(request, profile_id):
     root_url = request.build_absolute_uri('/')
-    return '%siwc-api/profile/%s/' % (root_url, profile_id)
+    return '{0!s}iwc-api/profile/{1!s}/'.format(root_url, profile_id)
 
 
 def get_abs_url_for_iwc(request):
     root_url = request.build_absolute_uri('/')
-    return '%siwc-api/' % root_url
+    return '{0!s}iwc-api/'.format(root_url)
 
 
 def add_link_item(url, data, type='application/json'):
@@ -88,7 +88,7 @@ def generate_content_type(type, version=2):
         # version number found already - just use what's there
         return type
     except IndexError:
-        return '%s;version=%s' % (type, version)
+        return '{0!s};version={1!s}'.format(type, version)
 
 
 def validate_version(accept_header):

--- a/ozpiwc/models.py
+++ b/ozpiwc/models.py
@@ -33,7 +33,7 @@ class DataResource(models.Model):
         unique_together = ('username', 'key')
 
     def __repr__(self):
-        return '%s:%s' % (self.username, self.key)
+        return '{0!s}:{1!s}'.format(self.username, self.key)
 
     def __str__(self):
-        return '%s:%s' % (self.username, self.key)
+        return '{0!s}:{1!s}'.format(self.username, self.key)

--- a/ozpiwc/tst_iwc_compatible_server.py
+++ b/ozpiwc/tst_iwc_compatible_server.py
@@ -43,7 +43,7 @@ class TestIwcBackend(unittest.TestCase):
         self.assertTrue(r['_embedded']['ozp:system'])
         self.assertTrue(r['_embedded']['ozp:system']['version'])
         self.assertTrue(r['_embedded']['ozp:system']['name'])
-        self.assertEqual(r['_embedded']['ozp:system']['_links']['self']['href'], '%s/system/' % IWC_ROOT)
+        self.assertEqual(r['_embedded']['ozp:system']['_links']['self']['href'], '{0!s}/system/'.format(IWC_ROOT))
 
         # check for embedded user details
         self.assertTrue(r['_embedded']['ozp:user'])
@@ -53,7 +53,7 @@ class TestIwcBackend(unittest.TestCase):
 
     def test_data_api(self):
         key = '/transportation/car7'
-        url = '%s/self/data%s/' % (IWC_ROOT, key)
+        url = '{0!s}/self/data{1!s}/'.format(IWC_ROOT, key)
         # delete this entry, in case it already exists
         r = self.make_delete_request(url, True)
 
@@ -103,7 +103,7 @@ class TestIwcBackend(unittest.TestCase):
         }
 
         key = '/transportation/truck3'
-        url = '%s/self/data%s/' % (IWC_ROOT, key)
+        url = '{0!s}/self/data{1!s}/'.format(IWC_ROOT, key)
         # delete this entry, in case it already exists
         r = self.make_delete_request(url, True)
         r = self.make_put_request(url, data, 201)
@@ -118,7 +118,7 @@ class TestIwcBackend(unittest.TestCase):
         self.assertTrue(len(r['_links']['item'][0]['href']))
 
         # test deleting a key
-        url = '%s/self/data%s/' % (IWC_ROOT, key)
+        url = '{0!s}/self/data{1!s}/'.format(IWC_ROOT, key)
         r = self.make_delete_request(url, 204)
         # should now get a 404 trying to get this key
         r = self.make_get_request(url, 404)

--- a/ozpiwc/views.py
+++ b/ozpiwc/views.py
@@ -34,39 +34,39 @@ def RootApiView(request):
     data = hal.create_base_structure(request,
         hal.generate_content_type(request.accepted_media_type))
     data['_links'][hal.APPLICATION_REL] = {
-        "href": '%sself/application/' % (hal.get_abs_url_for_iwc(request)),
+        "href": '{0!s}self/application/'.format((hal.get_abs_url_for_iwc(request))),
         "type": hal.generate_content_type(
             renderers.ApplicationListResourceRenderer.media_type)
     }
     data['_links'][hal.INTENT_REL] = {
-        "href": '%sself/intent/' % (hal.get_abs_url_for_iwc(request)),
+        "href": '{0!s}self/intent/'.format((hal.get_abs_url_for_iwc(request))),
         "type": hal.generate_content_type(
             renderers.IntentListResourceRenderer.media_type)
     }
     data['_links'][hal.SYSTEM_REL] = {
-        "href": '%siwc-api/system/' % (root_url),
+        "href": '{0!s}iwc-api/system/'.format((root_url)),
         "type": hal.generate_content_type(
             renderers.SystemResourceRenderer.media_type)
     }
     data['_links'][hal.USER_REL] = {
-        "href": '%sself/' % (hal.get_abs_url_for_iwc(request)),
+        "href": '{0!s}self/'.format((hal.get_abs_url_for_iwc(request))),
         "type": hal.generate_content_type(
             renderers.UserResourceRenderer.media_type)
     }
     data['_links'][hal.USER_DATA_REL] = {
-        "href": '%sself/data/' % (hal.get_abs_url_for_iwc(request)),
+        "href": '{0!s}self/data/'.format((hal.get_abs_url_for_iwc(request))),
         "type": hal.generate_content_type(
             renderers.DataObjectListResourceRenderer.media_type)
     }
 
     data['_links'][hal.DATA_ITEM_REL] = {
-        "href": '%sself/data/{+resource}' % (hal.get_abs_url_for_iwc(request)),
+        "href": '{0!s}self/data/{{+resource}}'.format((hal.get_abs_url_for_iwc(request))),
         "type": hal.generate_content_type(renderers.DataObjectResourceRenderer.media_type),
         "templated": True
     }
 
     data['_links'][hal.APPLICATION_ITEM_REL] = {
-        "href": '%slisting/{+resource}/' % (hal.get_abs_url_for_iwc(request)),
+        "href": '{0!s}listing/{{+resource}}/'.format((hal.get_abs_url_for_iwc(request))),
         "type": hal.generate_content_type(renderers.ApplicationResourceRenderer.media_type),
         "templated": True
     }
@@ -77,7 +77,7 @@ def RootApiView(request):
         "name": profile.display_name,
         "_links": {
             "self": {
-                "href": '%sself/' % (hal.get_abs_url_for_iwc(request)),
+                "href": '{0!s}self/'.format((hal.get_abs_url_for_iwc(request))),
                 "type": hal.generate_content_type(
                     renderers.UserResourceRenderer.media_type)
             }
@@ -89,7 +89,7 @@ def RootApiView(request):
         "name": 'TBD',
         "_links": {
             "self": {
-                "href": '%ssystem/' % (hal.get_abs_url_for_iwc(request)),
+                "href": '{0!s}system/'.format((hal.get_abs_url_for_iwc(request))),
                 "type": hal.generate_content_type(
                     renderers.SystemResourceRenderer.media_type)
             }

--- a/plugins/default_access_control/main.py
+++ b/plugins/default_access_control/main.py
@@ -145,7 +145,7 @@ class PluginMain(object):
         try:
             user_accesses = json.loads(user_accesses_json)
         except ValueError:
-            logger.error('Error parsing JSON data: %s' % user_accesses_json)
+            logger.error('Error parsing JSON data: {0!s}'.format(user_accesses_json))
             return False
 
         # check clearances

--- a/plugins/default_access_control/tokens.py
+++ b/plugins/default_access_control/tokens.py
@@ -10,13 +10,13 @@ class Token(object):
         self.long_name = long_name
 
     def __str__(self):
-        return '%s(%s)' % (self.token_type, self.long_name)
+        return '{0!s}({1!s})'.format(self.token_type, self.long_name)
 
     def __repr__(self):
-        return '%s(%s)' % (self.token_type, self.long_name)
+        return '{0!s}({1!s})'.format(self.token_type, self.long_name)
 
     def __unicode__(self):
-        return u'%s(%s)' % (self.token_type, self.long_name)
+        return u'{0!s}({1!s})'.format(self.token_type, self.long_name)
 
 
 class InvalidFormatToken(Token):

--- a/plugins/default_authorization/main.py
+++ b/plugins/default_authorization/main.py
@@ -64,13 +64,13 @@ class PluginMain(object):
         # logger.debug('hitting url %s for user with dn %s' % (url, profile.dn), extra={'request':request})
 
         if r.status_code != 200:
-            raise errors.AuthorizationFailure('Error contacting authorization server: %s' % r.text)
+            raise errors.AuthorizationFailure('Error contacting authorization server: {0!s}'.format(r.text))
         user_data = r.json()
 
         user_json_keys = ['dn', 'formalAccesses', 'clearances', 'dutyorg', 'visas']
         for user_key in user_json_keys:
             if user_key not in user_data:
-                raise ValueError('Endpoint %s not return value output - missing key: %s' % (url, user_key))
+                raise ValueError('Endpoint {0!s} not return value output - missing key: {1!s}'.format(url, user_key))
 
         # convert dutyorg -> duty_org
         user_data['duty_org'] = user_data['dutyorg']
@@ -85,11 +85,11 @@ class PluginMain(object):
         # logger.debug('hitting url %s for user with dn %s for group info' % (url, profile.dn), extra={'request':request})
         r = self.requests.get(url, cert=(server_crt, server_key), verify=False)
         if r.status_code != 200:
-            raise errors.AuthorizationFailure('Error contacting authorization server: %s' % r.text)
+            raise errors.AuthorizationFailure('Error contacting authorization server: {0!s}'.format(r.text))
         group_data = r.json()
 
         if 'groups' not in group_data:
-            raise ValueError('Endpoint %s not return value output - missing key: %s' % (url, 'groups'))
+            raise ValueError('Endpoint {0!s} not return value output - missing key: {1!s}'.format(url, 'groups'))
 
         groups = group_data['groups']
         user_data['is_org_steward'] = False
@@ -123,7 +123,7 @@ class PluginMain(object):
 
         profile = model_access.get_profile(username)
         if not profile:
-            raise errors.NotFound('User %s was not found - cannot update authorization info' % username)
+            raise errors.NotFound('User {0!s} was not found - cannot update authorization info'.format(username))
 
         # check profile.auth_expires. if auth_expires - now > 24 hours, raise an
         # exception (auth data should never be cached for more than 24 hours)
@@ -133,7 +133,7 @@ class PluginMain(object):
             raise errors.AuthorizationFailure('Cannot cache data for more than 1 day')
         expires_in = profile.auth_expires - now
         if expires_in.days >= 1:
-            raise errors.AuthorizationFailure('User %s had auth expires set to expire in more than 24 hours' % username)
+            raise errors.AuthorizationFailure('User {0!s} had auth expires set to expire in more than 24 hours'.format(username))
 
         # if auth_data cache hasn't expired, we're good to go
         # TODO: might want to check and see if auth expires in 12 hours
@@ -142,7 +142,7 @@ class PluginMain(object):
         # help to alleviate errors due to the authorization service being down
         # Example: '2016-04-18 15:57:09.275093+00:00' <= '2016-04-18 16:36:05.825269+00:00' = True
         if now <= profile.auth_expires:
-            logger.debug('no auth refresh required. Expires in %s seconds' % expires_in.seconds,
+            logger.debug('no auth refresh required. Expires in {0!s} seconds'.format(expires_in.seconds),
                          extra={'request': request, 'method': method})
             return True
 
@@ -161,7 +161,7 @@ class PluginMain(object):
             if (hasattr(settings, 'DEFAULT_AGENCY') and (settings.DEFAULT_AGENCY != '')):
                 duty_org = settings.DEFAULT_AGENCY
             else:
-                raise errors.AuthorizationFailure('User %s has invalid duty org %s' % (username, duty_org))
+                raise errors.AuthorizationFailure('User {0!s} has invalid duty org {1!s}'.format(username, duty_org))
 
         # update the user's org
         try:
@@ -169,7 +169,7 @@ class PluginMain(object):
             org = models.Agency.objects.get(short_name=duty_org)
             profile.organizations.add(org)
         except Exception as e:
-            logger.error('Failed to update organizations for user %s. Error: %s' % (username, str(e)),
+            logger.error('Failed to update organizations for user {0!s}. Error: {1!s}'.format(username, str(e)),
                          extra={'request': request, 'method': method})
             return False
 

--- a/plugins/default_authorization/tests/mock.py
+++ b/plugins/default_authorization/tests/mock.py
@@ -10,7 +10,7 @@ TEST_BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 def _load_json_file():
-    with open('%s/%s' % (TEST_BASE_DIR, 'tests/auth_data.json')) as json_data:
+    with open('{0!s}/{1!s}'.format(TEST_BASE_DIR, 'tests/auth_data.json')) as json_data:
         auth_data = json.load(json_data)
         return auth_data
 

--- a/plugins_util/plugin_manager.py
+++ b/plugins_util/plugin_manager.py
@@ -44,13 +44,13 @@ class DynamicImporterWrapper(object):
             self.error_message = error_message
 
     def __str__(self):
-        return '(%s,%s,%s)' % (self.input_module, self.input_class, self.error)
+        return '({0!s},{1!s},{2!s})'.format(self.input_module, self.input_class, self.error)
 
     def __unicode__(self):
-        return u'(%s,%s,%s)' % (self.input_module, self.input_class, self.error)
+        return u'({0!s},{1!s},{2!s})'.format(self.input_module, self.input_class, self.error)
 
     def __repr__(self):
-        return '(%s,%s,%s)' % (self.input_module, self.input_class, self.error)
+        return '({0!s},{1!s},{2!s})'.format(self.input_module, self.input_class, self.error)
 
 
 def dynamic_importer(name, class_name=None):
@@ -65,19 +65,19 @@ def dynamic_importer(name, class_name=None):
     current_module_found = current_module is not None
 
     if not current_module_found:
-        return DynamicImporterWrapper(None, None, 'Unable to locate module: %s' % name)
+        return DynamicImporterWrapper(None, None, 'Unable to locate module: {0!s}'.format(name))
 
     try:
         loaded_module = current_module.loader.load_module()
     except Exception as e:
         traceback.print_exc()
-        return DynamicImporterWrapper(None, None, 'Error Loading module: %s - Reason:%s' % (name, str(e.__traceback__)))
+        return DynamicImporterWrapper(None, None, 'Error Loading module: {0!s} - Reason:{1!s}'.format(name, str(e.__traceback__)))
 
     if class_name:
         if getattr(loaded_module, class_name, None):
             return DynamicImporterWrapper(loaded_module, loaded_module.PluginMain)
         else:
-            return DynamicImporterWrapper(loaded_module, None, 'Unable to locate Plugin Entry Point: %s' % name)
+            return DynamicImporterWrapper(loaded_module, None, 'Unable to locate Plugin Entry Point: {0!s}'.format(name))
     else:
         return DynamicImporterWrapper(loaded_module, None)
 
@@ -92,7 +92,7 @@ def dynamic_directory_importer(path=BASE_PLUGIN_DIRECTORY):
     for infile in listing:
         if os.path.isdir(os.path.join(path, infile)):
             if(os.path.isfile(os.path.join(path, infile, 'main.py'))):
-                current_importer = dynamic_importer('plugins.%s.main' % infile, 'PluginMain')
+                current_importer = dynamic_importer('plugins.{0!s}.main'.format(infile), 'PluginMain')
                 output_list.append(current_importer)
     return output_list
 
@@ -107,7 +107,7 @@ def dynamic_mock_service_importer(path=BASE_PLUGIN_DIRECTORY):
     for infile in listing:
         if os.path.isdir(os.path.join(path, infile)):
             if(os.path.isfile(os.path.join(path, infile, 'tests', 'mock.py'))):
-                current_importer = dynamic_importer('plugins.%s.tests.mock' % infile)
+                current_importer = dynamic_importer('plugins.{0!s}.tests.mock'.format(infile))
                 output_list.append(current_importer)
     return output_list
 
@@ -136,11 +136,11 @@ class PluginManager(object):
 
             for importer_wrapper in dynamic_directory_importer(path):
                 if importer_wrapper.error:
-                    logger.error('Error Loading Plugin: %s - Error Message %s ' % (importer_wrapper, importer_wrapper.error_message))
+                    logger.error('Error Loading Plugin: {0!s} - Error Message {1!s} '.format(importer_wrapper, importer_wrapper.error_message))
                 else:
                     current_class_instance = importer_wrapper.input_class(settings=settings, requests=requests)
                     self.instances[current_class_instance.plugin_name] = current_class_instance
-                    logger.info('Success Loading Plugin: %s' % importer_wrapper)
+                    logger.info('Success Loading Plugin: {0!s}'.format(importer_wrapper))
 
     def __getattr__(self, plugin_name, path=BASE_PLUGIN_DIRECTORY):
         """
@@ -152,7 +152,7 @@ class PluginManager(object):
             return plugin_instance
         else:
             # Default behaviour
-            raise AttributeError('Class missing method: %s' % name)
+            raise AttributeError('Class missing method: {0!s}'.format(name))
 
     def load_mock_services(self, router_instance, path=BASE_PLUGIN_DIRECTORY):
         """
@@ -173,7 +173,7 @@ class PluginManager(object):
             if hasattr(current_module, 'urls'):
                 # Found Urls in
                 router_instance.add_urls(current_module.urls)
-                logger.info('Loaded Mock Services for %s ' % current_module)
+                logger.info('Loaded Mock Services for {0!s} '.format(current_module))
 
     def get_plugin_instance(self, plugin_name, path=BASE_PLUGIN_DIRECTORY):
         """

--- a/release.py
+++ b/release.py
@@ -56,7 +56,7 @@ def get_version():
         return verstr
     else:
         raise RuntimeError(
-            "Unable to find version string in %s." % (VERSION_FILE,))
+            "Unable to find version string in {0!s}.".format(VERSION_FILE))
 
 
 def get_date_time():
@@ -75,7 +75,7 @@ def cleanup():
     shutil.rmtree("dist", ignore_errors=True)
     shutil.rmtree("build", ignore_errors=True)
     shutil.rmtree("release", ignore_errors=True)
-    shutil.rmtree("%s.egg-info" % PACKAGE, ignore_errors=True)
+    shutil.rmtree("{0!s}.egg-info".format(PACKAGE), ignore_errors=True)
 
 
 def create_release_dir():
@@ -133,11 +133,11 @@ def run():
     # tar everything up
     if args.version:
         version = get_version()
-        call("tar -czf %s-%s.tar.gz release" % ('backend', version),
+        call("tar -czf {0!s}-{1!s}.tar.gz release".format('backend', version),
              shell=True)
     else:
         date = get_date_time()
-        call("tar -czf %s-%s.tar.gz release" % ('backend', date),
+        call("tar -czf {0!s}-{1!s}.tar.gz release".format('backend', date),
              shell=True)
 
     # cleanup build dirs

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ mo = re.search(VSRE, verstrline, re.M)
 if mo:
     verstr = mo.group(1)
 else:
-    raise RuntimeError("Unable to find version string in %s." % (VERSIONFILE,))
+    raise RuntimeError("Unable to find version string in {0!s}.".format(VERSIONFILE))
 
 
 install_requires = [


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:ozone-development:ozp-backend?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:ozone-development:ozp-backend?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)